### PR TITLE
add necessary backslash to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ start-api:
 		git clone https://$(VINYLDNS_REPO) $(GOPATH)/src/$(VINYLDNS_REPO); \
 	fi
 	$(GOPATH)/src/$(VINYLDNS_REPO)/bin/docker-up-vinyldns.sh \
-		--api-only
+		--api-only \
 		--version 0.8.0
 
 stop-api:


### PR DESCRIPTION
### Description of the Change

the makefile is currently missing a `\` and as a result, running `make` will cause vinyl to start with the default version string of "latest", and you'll get some errors in the output, produced below:
```
$ make
go get -u github.com/golang/dep/cmd/dep
dep ensure
go vet ./...
go test ./... -cover
ok      github.com/vinyldns/go-vinyldns/vinyldns        (cached)        coverage: 78.1% of stat
ements
if [ ! -d "/home/shua/go//src/github.com/vinyldns/vinyldns" ]; then \
        echo "github.com/vinyldns/vinyldns not found in your GOPATH (necessary for acceptance t
ests), getting..."; \
        git clone https://github.com/vinyldns/vinyldns /home/shua/go//src/github.com/vinyldns/v
inyldns; \
fi
/home/shua/go//src/github.com/vinyldns/vinyldns/bin/docker-up-vinyldns.sh \
        --api-only
timeout is set to 60
vinyldns version is set to latest
Starting vinyldns and all dependencies in the background...
Creating network "docker_default" with the default driver
Creating vinyldns-mysql     ... done
Creating vinyldns-bind9     ... done
Creating vinyldns-elasticmq ... done
Creating vinyldns-dynamodb  ... done
Creating vinyldns-api       ... done
Waiting for api...
pinging http://localhost:9000 ...
Retrying Again
Retrying Again
Succeeded in connecting to http://localhost:9000!
version 0.8.0
make: version: Command not found
make: [Makefile:27: start-api] Error 127 (ignored)
go test ./... -tags=integration
ok      github.com/vinyldns/go-vinyldns/vinyldns        (cached)
./../vinyldns/bin/remove-vinyl-containers.sh
killing...
a547c64933ea 5b5392980f4a f4b6858410a5 ba217f5a8ac6 82bc8128cf0f

removing...
a547c64933ea 5b5392980f4a f4b6858410a5 ba217f5a8ac6 82bc8128cf0f

pruning network...
Deleted Networks:
docker_default

go install ./...
```
note specifically the lines `vinyldns version is set to latest` and
```
version 0.8.0
make: version: Command not found
make: [Makefile:27: start-api] Error 127 (ignored)
```

### Verification Process

ran `make` and it succeeded without errors, output produced below:
```
$ make
go get -u github.com/golang/dep/cmd/dep
dep ensure
go vet ./...
go test ./... -cover
ok      github.com/vinyldns/go-vinyldns/vinyldns        (cached)        coverage: 78.1% of stat
ements
if [ ! -d "/home/shua/go//src/github.com/vinyldns/vinyldns" ]; then \
        echo "github.com/vinyldns/vinyldns not found in your GOPATH (necessary for acceptance t
ests), getting..."; \
        git clone https://github.com/vinyldns/vinyldns /home/shua/go//src/github.com/vinyldns/v
inyldns; \
fi
/home/shua/go//src/github.com/vinyldns/vinyldns/bin/docker-up-vinyldns.sh \
        --api-only \
        --version 0.8.0
timeout is set to 60
vinyldns version is set to 0.8.0
Starting vinyldns and all dependencies in the background...
Creating network "docker_default" with the default driver
Creating vinyldns-dynamodb  ... done
Creating vinyldns-mysql     ... done
Creating vinyldns-bind9     ... done
Creating vinyldns-elasticmq ... done
Creating vinyldns-api       ... done
Waiting for api...
pinging http://localhost:9000 ...

Retrying Again
Succeeded in connecting to http://localhost:9000!
go test ./... -tags=integration
ok      github.com/vinyldns/go-vinyldns/vinyldns        28.192s
./../vinyldns/bin/remove-vinyl-containers.sh
killing...
Error response from daemon: Cannot kill container: d4c4d80ccaa5: Container d4c4d80ccaa5313d05a5
1302282b56a3635e47224a7730cf22977c01d48d6850 is not running
Error response from daemon: Cannot kill container: a4e2e7339ef4: Container a4e2e7339ef43a9235ea
1b33987de5bb5d9122804f014ca5b8882b5e6b8a7997 is not running
Error response from daemon: Cannot kill container: 0a4f17e19683: Container 0a4f17e196834a3fffef
06e6cc0c2a1b1e11be00acd643634fc4216b88b5a484 is not running
Error response from daemon: Cannot kill container: 6dbf5b217781: Container 6dbf5b217781b1e7b16e
c0494e06192d5d1116f24c9b38be16a1edeca639fa6d is not running
eb4bbefdd15b 2c99f8559dbd 401fdf452cf7 14c6dde87069 2dccf2af71ec

removing...
eb4bbefdd15b 2c99f8559dbd 401fdf452cf7 14c6dde87069 2dccf2af71ec d4c4d80ccaa5 a4e2e7339ef4 0a4f
17e19683 6dbf5b217781

pruning network...
Deleted Networks:
docker_default
709065_default
706260_default

go install ./...
```
