### PR TITLE
Ensure empty slices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.8.3
+VERSION=0.8.4
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
 

--- a/vinyldns/api.go
+++ b/vinyldns/api.go
@@ -231,7 +231,7 @@ func (c *Client) RecordSetsListAll(zoneID string, filter ListFilter) ([]RecordSe
 		return nil, fmt.Errorf("MaxItems must be between 1 and 100")
 	}
 
-	var rss []RecordSet
+	rss := []RecordSet{}
 
 	for {
 		resp, err := c.recordSetsList(zoneID, filter)

--- a/vinyldns/api.go
+++ b/vinyldns/api.go
@@ -36,7 +36,7 @@ func (c *Client) ZonesListAll(filter ListFilter) ([]Zone, error) {
 		return nil, fmt.Errorf("MaxItems must be between 1 and 100")
 	}
 
-	var zones []Zone
+	zones := []Zone{}
 
 	for {
 		resp, err := c.zonesList(filter)

--- a/vinyldns/api_test.go
+++ b/vinyldns/api_test.go
@@ -173,7 +173,7 @@ func TestZonesListAllWhenNone(t *testing.T) {
 	}
 
 	if string(j) != "[]" {
-		t.Error("Expected marshaled JSON to be '[]'; got ", string(j))
+		t.Error("Expected string-converted marshaled JSON to be '[]'; got ", string(j))
 	}
 }
 
@@ -549,6 +549,36 @@ func TestRecordSetsListAll(t *testing.T) {
 
 	if records[1].ID != "2" {
 		t.Error("Expected RecordSet.ID to be 2")
+	}
+}
+
+func TestRecordSetsListAllWhenNoneExist(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		testToolsConfig{
+			endpoint: "http://host.com/zones/123/recordsets",
+			code:     200,
+			body:     recordSetsListNoneJSON,
+		},
+	})
+
+	defer server.Close()
+
+	records, err := client.RecordSetsListAll("123", ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(records) != 0 {
+		t.Error("Expected 0 records; got ", len(records))
+	}
+
+	j, err := json.Marshal(records)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(j) != "[]" {
+		t.Error("Expected string-converted marshaled JSON to be '[]'; got ", string(j))
 	}
 }
 

--- a/vinyldns/api_test.go
+++ b/vinyldns/api_test.go
@@ -14,6 +14,7 @@ package vinyldns
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -143,6 +144,36 @@ func TestZonesListAll(t *testing.T) {
 
 	if zones[1].ID != "2" {
 		t.Error("Expected Zone.ID to be 2")
+	}
+}
+
+func TestZonesListAllWhenNone(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		testToolsConfig{
+			endpoint: "http://host.com/zones",
+			code:     200,
+			body:     zonesListNoneJSON,
+		},
+	})
+
+	defer server.Close()
+
+	zones, err := client.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(zones) != 0 {
+		t.Error("Expected 0 Zones; got ", len(zones))
+	}
+
+	j, err := json.Marshal(zones)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(j) != "[]" {
+		t.Error("Expected marshaled JSON to be '[]'; got ", string(j))
 	}
 }
 

--- a/vinyldns/json_fixtures_test.go
+++ b/vinyldns/json_fixtures_test.go
@@ -146,6 +146,11 @@ const (
 			}
 		}]}`
 
+	zonesListNoneJSON = `{
+		"maxItems": 100,
+		"zones": []
+	}`
+
 	zoneJSON = `{
 		"zone":{
 			"name":"vinyldns.",

--- a/vinyldns/json_fixtures_test.go
+++ b/vinyldns/json_fixtures_test.go
@@ -359,6 +359,11 @@ const (
 		}]
 	}`
 
+	recordSetsListNoneJSON = `{
+		"maxItems": 100,
+		"recordSets": []
+	}`
+
 	recordSetUpdateResponseJSON = `{
 		"zone": {
 			"name": "vinyldnstest.sys.vinyldns.net.",


### PR DESCRIPTION
This ensures that `ZonesListAll` and `RecordSetsListAll` will return an empty slice, even in instances where no zones or record sets were returned by the VinylDNS API response.

This is useful, for example, in ensuring `[]` -- rather than `null` -- is printed when doing things such as as `vinyldns zones --output=json` from the [vinyldns-cli](https://github.com/vinyldns/vinyldns-cli).

See [TravisCI vinyldns-cli/jobs/522997788](https://travis-ci.org/vinyldns/vinyldns-cli/jobs/522997788#L572-L575) for an example of the scenario this seeks to protect against.