### PR TITLE
Owner group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ start-api:
 	fi
 	$(GOPATH)/src/$(VINYLDNS_REPO)/bin/docker-up-vinyldns.sh \
 		--api-only \
-		--version 0.9.0
+		--version 0.9.1
 
 stop-api:
 	./../vinyldns/bin/remove-vinyl-containers.sh

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ start-api:
 	fi
 	$(GOPATH)/src/$(VINYLDNS_REPO)/bin/docker-up-vinyldns.sh \
 		--api-only \
-		--version 0.8.0
+		--version 0.9.0
 
 stop-api:
 	./../vinyldns/bin/remove-vinyl-containers.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.8.4
+VERSION=0.9.0
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
 

--- a/vinyldns/api_test.go
+++ b/vinyldns/api_test.go
@@ -651,6 +651,9 @@ func TestRecordSet(t *testing.T) {
 	if rs.ID != "123" {
 		t.Error("Expected RecordSet.Id to have a value")
 	}
+	if rs.OwnerGroupID != "456" {
+		t.Error("Expected RecordSet.OwnerGroupID to have a value")
+	}
 	if rs.ZoneID != "456" {
 		t.Error("Expected RecordSet.ZoneId to have a value")
 	}

--- a/vinyldns/api_test.go
+++ b/vinyldns/api_test.go
@@ -651,7 +651,7 @@ func TestRecordSet(t *testing.T) {
 	if rs.ID != "123" {
 		t.Error("Expected RecordSet.Id to have a value")
 	}
-	if rs.OwnerGroupID != "456" {
+	if rs.OwnerGroupID != "789" {
 		t.Error("Expected RecordSet.OwnerGroupID to have a value")
 	}
 	if rs.ZoneID != "456" {

--- a/vinyldns/json_fixtures_test.go
+++ b/vinyldns/json_fixtures_test.go
@@ -413,7 +413,7 @@ const (
 	recordSetJSON = `{
 		"recordSet":{
 			"id":"123",
-			"ownerGroupId":"456",
+			"ownerGroupId":"789",
 			"zoneId":"456",
 			"name":"test-01",
 			"type":"A",

--- a/vinyldns/json_fixtures_test.go
+++ b/vinyldns/json_fixtures_test.go
@@ -413,6 +413,7 @@ const (
 	recordSetJSON = `{
 		"recordSet":{
 			"id":"123",
+			"ownerGroupId":"456",
 			"zoneId":"456",
 			"name":"test-01",
 			"type":"A",

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -287,8 +287,9 @@ type RecordChange struct {
 
 // BatchRecordChangeUpdateResponse is represents a batch record change create or update response
 type BatchRecordChangeUpdateResponse struct {
-	Comments string         `json:"comments,omitempty"`
-	Changes  []RecordChange `json:"changes,omitempty"`
+	Comments     string         `json:"comments,omitempty"`
+	OwnerGroupID string         `json:"ownerGroupId,omitempty"`
+	Changes      []RecordChange `json:"changes,omitempty"`
 }
 
 // RecordData is represents a batch record change record data.

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -144,16 +144,17 @@ type RecordSetChange struct {
 
 // RecordSet represents a DNS record set.
 type RecordSet struct {
-	ID      string   `json:"id,omitempty"`
-	ZoneID  string   `json:"zoneId"`
-	Name    string   `json:"name,omitempty"`
-	Type    string   `json:"type"`
-	Status  string   `json:"status,omitempty"`
-	Created string   `json:"created,omitempty"`
-	Updated string   `json:"updated,omitempty"`
-	TTL     int      `json:"ttl"`
-	Account string   `json:"account"`
-	Records []Record `json:"records"`
+	ID           string   `json:"id,omitempty"`
+	ZoneID       string   `json:"zoneId"`
+	OwnerGroupID string   `json:"ownerGroupId,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Type         string   `json:"type"`
+	Status       string   `json:"status,omitempty"`
+	Created      string   `json:"created,omitempty"`
+	Updated      string   `json:"updated,omitempty"`
+	TTL          int      `json:"ttl"`
+	Account      string   `json:"account"`
+	Records      []Record `json:"records"`
 }
 
 // RecordSetUpdateResponse represents

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -86,6 +86,7 @@ type Zone struct {
 	Connection         *ZoneConnection `json:"connection,omitempty"`
 	TransferConnection *ZoneConnection `json:"transferConnection,omitempty"`
 	ACL                *ZoneACL        `json:"acl,omitempty"`
+	Shared             bool            `json:"shared,omitempty"`
 }
 
 // ZoneResponse represents the JSON response

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -263,7 +263,7 @@ type BatchRecordChanges struct {
 	BatchChanges []RecordChange `json:"batchChanges,omitempty"`
 }
 
-// RecordChange is represents a batch record change.
+// RecordChange represents a batch record change.
 type RecordChange struct {
 	ID               string     `json:"id,omitempty"`
 	Status           string     `json:"status,omitempty"`
@@ -295,7 +295,7 @@ type RecordData struct {
 	PTRDName string `json:"ptrdname,omitempty"`
 }
 
-// BatchRecordChange is represents a batch record change API response.
+// BatchRecordChange represents a batch record change API response.
 type BatchRecordChange struct {
 	ID               string         `json:"id,omitempty"`
 	UserName         string         `json:"userName,omitempty"`
@@ -303,5 +303,6 @@ type BatchRecordChange struct {
 	Status           string         `json:"status,omitempty"`
 	Comments         string         `json:"comments,omitempty"`
 	CreatedTimestamp string         `json:"createdTimestamp,omitempty"`
+	OwnerGroupID     string         `json:"ownerGroupId,omitempty"`
 	Changes          []RecordChange `json:"changes,omitempty"`
 }

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -258,12 +258,13 @@ type GroupChanges struct {
 	Changes []GroupChange `json:"changes"`
 }
 
-// BatchRecordChanges represents a list of record changes.
+// BatchRecordChanges represents a list of record changes,
+// as returned by the list batch changes VinylDNS API endpoint.
 type BatchRecordChanges struct {
 	BatchChanges []RecordChange `json:"batchChanges,omitempty"`
 }
 
-// RecordChange represents a batch record change.
+// RecordChange represents an individual batch record change.
 type RecordChange struct {
 	ID               string     `json:"id,omitempty"`
 	Status           string     `json:"status,omitempty"`
@@ -280,6 +281,7 @@ type RecordChange struct {
 	UserID           string     `json:"userId,omitempty"`
 	CreatedTimestamp string     `json:"createdTimestamp,omitempty"`
 	Record           RecordData `json:"data,omitempty"`
+	OwnerGroupID     string     `json:"ownerGroupId,omitempty"`
 }
 
 // BatchRecordChangeUpdateResponse is represents a batch record change create or update response


### PR DESCRIPTION
This seeks to address issue #14 in support of the shared zones model. In particular...

* adds `Shared` to `Zone`
* adds `OwnerGroupID` to `RecordSet`
* adds `OwnerGroupID` to `RecordChange` (represents an individual batch change summary in the [list batch changes response](https://www.vinyldns.io/api/list-batchchanges.html))
* adds `OwnerGroupID` to `BatchRecordChangeUpdateResponse` (represents the [create batch change response](https://www.vinyldns.io/api/create-batchchange.html))
* adds `OwnerGroupID` to `BatchRecordChange` (Used to represent the batch change in a [create batch change](https://www.vinyldns.io/api/create-batchchange.html) request. represents an individual [get batch change response](https://www.vinyldns.io/api/get-batchchange.html). Note that `go-vinyldns` also uses `BatchRecordChange` to represent an individual [get batch change response](https://www.vinyldns.io/api/get-batchchange.html). However, the VinylDNS docs do not represent `ownerGroupId` as being present in a get batch change response -- is it?)
* bumps the version to `0.9.0`, which is a minor version bump. Is this accurate and inline with `VinylDNS`'s versioning expectations?