### PR TITLE
Simplify methods

### DIFF
--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -220,6 +220,54 @@ func TestRecordSetCreateIntegrationNSRecord(t *testing.T) {
 	}
 }
 
+func TestRecordSetUpdateIntegrationARecord(t *testing.T) {
+	c := client()
+	zs, err := c.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+	rs := &RecordSet{
+		Name:   "integration-test-record-set-update",
+		ZoneID: zs[0].ID,
+		Type:   "A",
+		TTL:    60,
+		Records: []Record{
+			{
+				Address: "127.0.0.1",
+			},
+		},
+	}
+	rc, err := c.RecordSetCreate(rs)
+	if err != nil {
+		t.Error(err)
+	}
+	createdID := rc.RecordSet.ID
+	limit := 10
+	for i := 0; i < limit; time.Sleep(10 * time.Second) {
+		i++
+
+		rg, err := c.RecordSet(zs[0].ID, createdID)
+		if err == nil && rg.ID != createdID {
+			t.Error(fmt.Sprintf("unable to get record set %s", createdID))
+		}
+		if err == nil && rg.ID == createdID {
+			updatedName := "updated-integration-test-record-set-update"
+			rs.ID = createdID
+			rs.Name = updatedName
+			u, err = c.RecordSetUpdate(rs)
+			if err == nil && u.ID != createdID && u.Name != updatedName {
+				t.Error(fmt.Sprintf("unable to updated record set %s", createdID))
+			}
+			break
+		}
+
+		if i == (limit - 1) {
+			fmt.Printf("%d retries reached in polling for record set %s", limit, createdID)
+			t.Error(err)
+		}
+	}
+}
+
 func TestRecordSetsListAllIntegrationFilterForExistentName(t *testing.T) {
 	c := client()
 	zs, err := c.ZonesListAll(ListFilter{})

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -255,7 +255,7 @@ func TestRecordSetUpdateIntegrationARecord(t *testing.T) {
 			rs.ID = createdID
 			rs.Name = updatedName
 			u, err := c.RecordSetUpdate(rs)
-			if err == nil && u.ID != createdID && u.Name != updatedName {
+			if err == nil && u.RecordSet.ID != createdID && u.RecordSet.Name != updatedName {
 				t.Error(fmt.Sprintf("unable to updated record set %s", createdID))
 			}
 			break

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -146,7 +146,7 @@ func TestRecordSetCreateIntegrationARecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	rc, err := c.RecordSetCreate(zs[0].ID, &RecordSet{
+	rc, err := c.RecordSetCreate(&RecordSet{
 		Name:   "integration-test",
 		ZoneID: zs[0].ID,
 		Type:   "A",
@@ -186,7 +186,7 @@ func TestRecordSetCreateIntegrationNSRecord(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	rc, err := c.RecordSetCreate(zs[0].ID, &RecordSet{
+	rc, err := c.RecordSetCreate(&RecordSet{
 		Name:   "integration-test",
 		ZoneID: zs[0].ID,
 		Type:   "NS",

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -254,7 +254,7 @@ func TestRecordSetUpdateIntegrationARecord(t *testing.T) {
 			updatedName := "updated-integration-test-record-set-update"
 			rs.ID = createdID
 			rs.Name = updatedName
-			u, err = c.RecordSetUpdate(rs)
+			u, err := c.RecordSetUpdate(rs)
 			if err == nil && u.ID != createdID && u.Name != updatedName {
 				t.Error(fmt.Sprintf("unable to updated record set %s", createdID))
 			}

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -142,13 +142,13 @@ func (c *Client) RecordSetCreate(rs *RecordSet) (*RecordSetUpdateResponse, error
 }
 
 // RecordSetUpdate updates the RecordSet matching the Zone ID and RecordSetID it's passed.
-func (c *Client) RecordSetUpdate(zoneID, recordSetID string, rs *RecordSet) (*RecordSetUpdateResponse, error) {
+func (c *Client) RecordSetUpdate(rs *RecordSet) (*RecordSetUpdateResponse, error) {
 	rsJSON, err := json.Marshal(rs)
 	if err != nil {
 		return nil, err
 	}
 	var resource = &RecordSetUpdateResponse{}
-	err = resourceRequest(c, recordSetEP(c, zoneID, recordSetID), "PUT", rsJSON, resource)
+	err = resourceRequest(c, recordSetEP(c, rs.ZoneID, rs.ID), "PUT", rsJSON, resource)
 	if err != nil {
 		return &RecordSetUpdateResponse{}, err
 	}

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -127,13 +127,13 @@ func (c *Client) RecordSet(zoneID, recordSetID string) (RecordSet, error) {
 }
 
 // RecordSetCreate creates the RecordSet it's passed in the Zone whose ID it's passed.
-func (c *Client) RecordSetCreate(zoneID string, rs *RecordSet) (*RecordSetUpdateResponse, error) {
+func (c *Client) RecordSetCreate(rs *RecordSet) (*RecordSetUpdateResponse, error) {
 	rsJSON, err := json.Marshal(rs)
 	if err != nil {
 		return nil, err
 	}
 	var resource = &RecordSetUpdateResponse{}
-	err = resourceRequest(c, recordSetsEP(c, zoneID), "POST", rsJSON, resource)
+	err = resourceRequest(c, recordSetsEP(c, rs.ZoneID), "POST", rsJSON, resource)
 	if err != nil {
 		return &RecordSetUpdateResponse{}, err
 	}

--- a/vinyldns/recordsets_test.go
+++ b/vinyldns/recordsets_test.go
@@ -213,7 +213,7 @@ func TestRecordSetCreate(t *testing.T) {
 		}},
 	}
 
-	r, err := client.RecordSetCreate("123", rs)
+	r, err := client.RecordSetCreate(rs)
 	if err != nil {
 		t.Log(pretty.PrettyFormat(r))
 		t.Error(err)

--- a/vinyldns/recordsets_test.go
+++ b/vinyldns/recordsets_test.go
@@ -245,6 +245,7 @@ func TestRecordSetUpdate(t *testing.T) {
 
 	rs := &RecordSet{
 		ZoneID: "123",
+		ID:     "456",
 		Name:   "name",
 		Type:   "CNAME",
 		TTL:    200,
@@ -253,7 +254,7 @@ func TestRecordSetUpdate(t *testing.T) {
 		}},
 	}
 
-	r, err := client.RecordSetUpdate("123", "456", rs)
+	r, err := client.RecordSetUpdate(rs)
 	if err != nil {
 		t.Log(pretty.PrettyFormat(r))
 		t.Error(err)


### PR DESCRIPTION
Fixes issue #5 to simplify `RecordSetCreate` and `RecordSetUpdate` methods.