### PR TITLE
Custom user agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.7
+VERSION=0.9.8
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION=0.9.7
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
 
-all: deps test start-api integration stop-api install
+all: deps test start-api integration stop-api validate-version install
 
 deps:
 	@go tool cover 2>/dev/null; if [ $$? -eq 3 ]; then \
@@ -20,6 +20,9 @@ test:
 
 integration:
 	go test $(SOURCE) -tags=integration
+
+validate-version:
+	cat vinyldns/version.go | fgrep 'var Version = "$(VERSION)"'
 
 start-api:
 	if [ ! -d "$(GOPATH)/src/$(VINYLDNS_REPO)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ integration:
 	go test $(SOURCE) -tags=integration
 
 validate-version:
-	cat vinyldns/version.go | fgrep 'var Version = "$(VERSION)"'
+	cat vinyldns/version.go | grep 'var Version = "$(VERSION)"'
 
 start-api:
 	if [ ! -d "$(GOPATH)/src/$(VINYLDNS_REPO)" ]; then \

--- a/vinyldns/client.go
+++ b/vinyldns/client.go
@@ -22,15 +22,22 @@ type ClientConfiguration struct {
 	AccessKey string
 	SecretKey string
 	Host      string
+	UserAgent string
 }
 
 // NewConfigFromEnv creates a new ClientConfiguration
 // using environment variables.
 func NewConfigFromEnv() ClientConfiguration {
+	ua := defaultUA()
+
+	if os.Getenv("VINYLDNS_USER_AGENT") != "" {
+		ua = os.Getenv("VINYLDNS_USER_AGENT")
+	}
 	return ClientConfiguration{
 		os.Getenv("VINYLDNS_ACCESS_KEY"),
 		os.Getenv("VINYLDNS_SECRET_KEY"),
 		os.Getenv("VINYLDNS_HOST"),
+		ua,
 	}
 }
 
@@ -39,6 +46,7 @@ type Client struct {
 	AccessKey  string
 	SecretKey  string
 	Host       string
+	UserAgent  string
 	HTTPClient *http.Client
 }
 
@@ -51,12 +59,21 @@ func NewClientFromEnv() *Client {
 // NewClient returns a new vinyldns client using
 // the client ClientConfiguration it's passed.
 func NewClient(config ClientConfiguration) *Client {
+	if config.UserAgent == "" {
+		config.UserAgent = defaultUA()
+	}
+
 	return &Client{
 		config.AccessKey,
 		config.SecretKey,
 		config.Host,
+		config.UserAgent,
 		&http.Client{},
 	}
+}
+
+func defaultUA() string {
+	return "go-vinyldns"
 }
 
 func logRequests() bool {

--- a/vinyldns/client.go
+++ b/vinyldns/client.go
@@ -31,8 +31,8 @@ type ClientConfiguration struct {
 func NewConfigFromEnv() ClientConfiguration {
 	ua := defaultUA()
 
-	if os.Getenv("VINYLDNS_USER_AGENT") != "" {
-		ua = os.Getenv("VINYLDNS_USER_AGENT")
+	if vua := os.Getenv("VINYLDNS_USER_AGENT"); vua != "" {
+		ua = vua
 	}
 	return ClientConfiguration{
 		os.Getenv("VINYLDNS_ACCESS_KEY"),
@@ -74,7 +74,7 @@ func NewClient(config ClientConfiguration) *Client {
 }
 
 func defaultUA() string {
-	return fmt.Sprintf("go-vinyldns / %s", Version)
+	return fmt.Sprintf("go-vinyldns/%s", Version)
 }
 
 func logRequests() bool {

--- a/vinyldns/client.go
+++ b/vinyldns/client.go
@@ -46,8 +46,8 @@ type Client struct {
 	AccessKey  string
 	SecretKey  string
 	Host       string
-	UserAgent  string
 	HTTPClient *http.Client
+	UserAgent  string
 }
 
 // NewClientFromEnv returns a Client configured via
@@ -67,8 +67,8 @@ func NewClient(config ClientConfiguration) *Client {
 		config.AccessKey,
 		config.SecretKey,
 		config.Host,
-		config.UserAgent,
 		&http.Client{},
+		config.UserAgent,
 	}
 }
 

--- a/vinyldns/client.go
+++ b/vinyldns/client.go
@@ -74,7 +74,7 @@ func NewClient(config ClientConfiguration) *Client {
 }
 
 func defaultUA() string {
-	return fmt.Sprintf("go-vinyldns %s", Version)
+	return fmt.Sprintf("go-vinyldns / %s", Version)
 }
 
 func logRequests() bool {

--- a/vinyldns/client.go
+++ b/vinyldns/client.go
@@ -13,6 +13,7 @@ limitations under the License.
 package vinyldns
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 )
@@ -73,7 +74,7 @@ func NewClient(config ClientConfiguration) *Client {
 }
 
 func defaultUA() string {
-	return "go-vinyldns"
+	return fmt.Sprintf("go-vinyldns %s", Version)
 }
 
 func logRequests() bool {

--- a/vinyldns/client_test.go
+++ b/vinyldns/client_test.go
@@ -20,6 +20,7 @@ import (
 func TestNewClientFromEnv(t *testing.T) {
 	os.Setenv("VINYLDNS_ACCESS_KEY", "accessKey")
 	os.Setenv("VINYLDNS_SECRET_KEY", "secretKey")
+	os.Setenv("VINYLDNS_HOST", "https://vinyldns-api.com")
 
 	client := NewClientFromEnv()
 
@@ -29,4 +30,26 @@ func TestNewClientFromEnv(t *testing.T) {
 	if client.SecretKey != "secretKey" {
 		t.Error("NewClientFromEnv should set a SecretKey from the environment")
 	}
+	if client.Host != "https://vinyldns-api.com" {
+		t.Error("NewClientFromEnv should set a Host from the environment")
+	}
+	if client.UserAgent != "go-vinyldns" {
+		t.Error("NewClientFromEnv should set a default UserAgent if one is not present in the environment")
+	}
+
+	os.Setenv("VINYLDNS_ACCESS_KEY", "")
+	os.Setenv("VINYLDNS_SECRET_KEY", "")
+	os.Setenv("VINYLDNS_HOST", "")
+}
+
+func TestNewClientFromEnvWithUserAgent(t *testing.T) {
+	os.Setenv("VINYLDNS_USER_AGENT", "foo")
+
+	client := NewClientFromEnv()
+
+	if client.UserAgent != "foo" {
+		t.Error("NewClientFromEnv should set a UserAgent from the environment if one is present")
+	}
+
+	os.Setenv("VINYLDNS_USER_AGENT", "")
 }

--- a/vinyldns/client_test.go
+++ b/vinyldns/client_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package vinyldns
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -33,7 +34,7 @@ func TestNewClientFromEnv(t *testing.T) {
 	if client.Host != "https://vinyldns-api.com" {
 		t.Error("NewClientFromEnv should set a Host from the environment")
 	}
-	if client.UserAgent != "go-vinyldns" {
+	if client.UserAgent != fmt.Sprintf("go-vinyldns %s", Version) {
 		t.Error("NewClientFromEnv should set a default UserAgent if one is not present in the environment")
 	}
 

--- a/vinyldns/client_test.go
+++ b/vinyldns/client_test.go
@@ -34,7 +34,7 @@ func TestNewClientFromEnv(t *testing.T) {
 	if client.Host != "https://vinyldns-api.com" {
 		t.Error("NewClientFromEnv should set a Host from the environment")
 	}
-	if client.UserAgent != fmt.Sprintf("go-vinyldns %s", Version) {
+	if client.UserAgent != fmt.Sprintf("go-vinyldns/%s", Version) {
 		t.Error("NewClientFromEnv should set a default UserAgent if one is not present in the environment")
 	}
 

--- a/vinyldns/config_test.go
+++ b/vinyldns/config_test.go
@@ -27,6 +27,15 @@ func TestNewConfigFromEnv(t *testing.T) {
 	expectSame(t, defaultConfig.AccessKey, accessKey, "defaultConfig.AccessKey")
 	expectSame(t, defaultConfig.SecretKey, secretKey, "defaultConfig.SecretKey")
 	expectSame(t, defaultConfig.Host, host, "defaultConfig.Host")
+	expectSame(t, defaultConfig.UserAgent, "go-vinyldns", "defaultConfig.UserAgent")
+}
+
+func TestNewConfigFromEnvWithExplicitUserAgent(t *testing.T) {
+	os.Setenv("VINYLDNS_USER_AGENT", "some customer UA")
+
+	defaultConfig := NewConfigFromEnv()
+
+	expectSame(t, defaultConfig.UserAgent, "some customer UA", "defaultConfig.UserAgent")
 }
 
 func TestNewClient(t *testing.T) {
@@ -34,17 +43,20 @@ func TestNewClient(t *testing.T) {
 		testAccessKey = "access granted"
 		testSecretKey = "this is very secret"
 		testHost      = "certainly.a.unique.host"
+		testUserAgent = "certainly.a.unique.userAgent"
 	)
 
 	client := NewClient(ClientConfiguration{
 		AccessKey: testAccessKey,
 		SecretKey: testSecretKey,
 		Host:      testHost,
+		UserAgent: testUserAgent,
 	})
 
 	expectSame(t, client.AccessKey, testAccessKey, "client.AccessKey")
 	expectSame(t, client.SecretKey, testSecretKey, "client.SecretKey")
 	expectSame(t, client.Host, testHost, "client.Host")
+	expectSame(t, client.UserAgent, testUserAgent, "client.UserAgent")
 }
 
 func envOrDefault(envVar, defaultValue string) string {

--- a/vinyldns/config_test.go
+++ b/vinyldns/config_test.go
@@ -13,6 +13,7 @@ limitations under the License.
 package vinyldns
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -27,7 +28,7 @@ func TestNewConfigFromEnv(t *testing.T) {
 	expectSame(t, defaultConfig.AccessKey, accessKey, "defaultConfig.AccessKey")
 	expectSame(t, defaultConfig.SecretKey, secretKey, "defaultConfig.SecretKey")
 	expectSame(t, defaultConfig.Host, host, "defaultConfig.Host")
-	expectSame(t, defaultConfig.UserAgent, "go-vinyldns", "defaultConfig.UserAgent")
+	expectSame(t, defaultConfig.UserAgent, fmt.Sprintf("go-vinyldns %s", Version), "defaultConfig.UserAgent")
 }
 
 func TestNewConfigFromEnvWithExplicitUserAgent(t *testing.T) {

--- a/vinyldns/config_test.go
+++ b/vinyldns/config_test.go
@@ -28,7 +28,7 @@ func TestNewConfigFromEnv(t *testing.T) {
 	expectSame(t, defaultConfig.AccessKey, accessKey, "defaultConfig.AccessKey")
 	expectSame(t, defaultConfig.SecretKey, secretKey, "defaultConfig.SecretKey")
 	expectSame(t, defaultConfig.Host, host, "defaultConfig.Host")
-	expectSame(t, defaultConfig.UserAgent, fmt.Sprintf("go-vinyldns %s", Version), "defaultConfig.UserAgent")
+	expectSame(t, defaultConfig.UserAgent, fmt.Sprintf("go-vinyldns/%s", Version), "defaultConfig.UserAgent")
 }
 
 func TestNewConfigFromEnvWithExplicitUserAgent(t *testing.T) {

--- a/vinyldns/endpoints_test.go
+++ b/vinyldns/endpoints_test.go
@@ -22,8 +22,8 @@ var c = &Client{
 	"accessKey",
 	"secretKey",
 	"http://host.com",
-	"go-vinyldns testing",
 	&http.Client{},
+	"go-vinyldns testing",
 }
 
 func TestZonesEP(t *testing.T) {

--- a/vinyldns/endpoints_test.go
+++ b/vinyldns/endpoints_test.go
@@ -22,6 +22,7 @@ var c = &Client{
 	"accessKey",
 	"secretKey",
 	"http://host.com",
+	"go-vinyldns testing",
 	&http.Client{},
 }
 

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -27,6 +27,7 @@ func client() *Client {
 		"okAccessKey",
 		"okSecretKey",
 		"http://localhost:9000",
+		"go-vinyldns integration testing",
 	})
 }
 

--- a/vinyldns/mock_testing_server_test.go
+++ b/vinyldns/mock_testing_server_test.go
@@ -65,6 +65,7 @@ func testTools(configs []testToolsConfig) (*httptest.Server, *Client) {
 		"accessToken",
 		"secretToken",
 		host,
+		"go-vinyldns testing",
 		&http.Client{Transport: tr},
 	}
 

--- a/vinyldns/mock_testing_server_test.go
+++ b/vinyldns/mock_testing_server_test.go
@@ -65,8 +65,8 @@ func testTools(configs []testToolsConfig) (*httptest.Server, *Client) {
 		"accessToken",
 		"secretToken",
 		host,
-		"go-vinyldns testing",
 		&http.Client{Transport: tr},
+		"go-vinyldns testing",
 	}
 
 	return server, client

--- a/vinyldns/util.go
+++ b/vinyldns/util.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/smartystreets/go-aws-auth"
+	awsauth "github.com/smartystreets/go-aws-auth"
 )
 
 func concat(arr []string) string {
@@ -48,6 +48,7 @@ func doClientReq(c *Client, method string, url string) (*http.Response, error) {
 	}
 
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", c.UserAgent)
 
 	awsauth.Sign4(req, awsauth.Credentials{
 		AccessKeyID:     c.AccessKey,

--- a/vinyldns/version.go
+++ b/vinyldns/version.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2018 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+// Version stores the go-vinyldns semantic version
+var Version = "0.9.7"

--- a/vinyldns/version.go
+++ b/vinyldns/version.go
@@ -13,4 +13,4 @@ limitations under the License.
 package vinyldns
 
 // Version stores the go-vinyldns semantic version
-var Version = "0.9.7"
+var Version = "0.9.8"


### PR DESCRIPTION
This seeks to address issue #9. I am also imagining that it paves a path towards a future where `terraform-provider-vinyldns` and `vinyldns-cli` can set custom `UserAgent`s such that usage statistics can be gleaned from logs.

* `Client{}` now has a `UserAgent` field
* `NewClientFromEnv()` will either look for a `VINYLDNS_USER_AGENT` env var or set `UserAgent` to `fmt.Sprintf("go-vinyldns %s", Version)`
* `go-vinyldns` now has a `Version`
* a `make validate-version` task errors if the `go-vinyldns/version.go`'s `var Version =` is not equal to the `VERSION` cited in the `Makefile`. While not ideal, it seems necessary to cite the version in two places such that 1) `make` can generate versioned releases and 2) `go-vinyldns` can include the version in a default `client.UserAgent`
* bump `go-vinyldns` patch version. While it's arguably not proper semantic versioning to only bump a patch version on what is ultimately a breaking change that now requires users to set a `client.UserAgent`, `go-vinyldns` should stay in lock step major/minor versioning with `vinyldns` itself, per agreement.