### PR TITLE
Fix for issue #43

### DIFF
--- a/vinyldns/batch_changes_resources.go
+++ b/vinyldns/batch_changes_resources.go
@@ -34,7 +34,7 @@ type RecordChange struct {
 	Comments         string     `json:"comments,omitempty"`
 	UserID           string     `json:"userId,omitempty"`
 	CreatedTimestamp string     `json:"createdTimestamp,omitempty"`
-	Record           RecordData `json:"data,omitempty"`
+	Record           RecordData `json:"record,omitempty"`
 	OwnerGroupID     string     `json:"ownerGroupId,omitempty"`
 }
 

--- a/vinyldns/batch_changes_test.go
+++ b/vinyldns/batch_changes_test.go
@@ -13,6 +13,8 @@ limitations under the License.
 package vinyldns
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/gobs/pretty"
@@ -24,7 +26,7 @@ func TestBatchRecordChanges(t *testing.T) {
 		t.Error(err)
 	}
 	server, client := testTools([]testToolsConfig{
-		testToolsConfig{
+		{
 			endpoint: "http://host.com/zones/batchrecordchanges",
 			code:     200,
 			body:     batchChangesJSON,
@@ -48,13 +50,55 @@ func TestBatchRecordChanges(t *testing.T) {
 	}
 }
 
+func TestBatchRecordChangeEncoding(t *testing.T) {
+	recordChangeJSON, err := readFile("test-fixtures/batch-changes/batch-recordchange-format.json")
+	if err != nil {
+		t.Error(err)
+	}
+
+	var shouldBe RecordChange
+	err = json.Unmarshal([]byte(recordChangeJSON), &shouldBe)
+	if err != nil {
+		t.Error(err)
+	}
+
+	reference := RecordChange{
+		ID:               "id",
+		Status:           "status",
+		Comments:         "comments",
+		ChangeType:       "changeType",
+		RecordName:       "recordName",
+		TTL:              1,
+		Type:             "type",
+		ZoneName:         "zoneName",
+		InputName:        "inputName",
+		ZoneID:           "zoneId",
+		TotalChanges:     1,
+		UserName:         "userName",
+		UserID:           "userId",
+		CreatedTimestamp: "createdTimeStamp",
+		Record: RecordData{
+			Address:  "address",
+			CName:    "cname",
+			PTRDName: "ptrdname",
+		},
+		OwnerGroupID: "ownerGroupId",
+	}
+
+	if !reflect.DeepEqual(shouldBe, reference) {
+		t.Log(shouldBe)
+		t.Log(reference)
+		t.Error("Expected unmarshalled batch recordchange to match manually created one")
+	}
+}
+
 func TestBatchRecordChange(t *testing.T) {
 	batchChangeJSON, err := readFile("test-fixtures/batch-changes/batch-change.json")
 	if err != nil {
 		t.Error(err)
 	}
 	server, client := testTools([]testToolsConfig{
-		testToolsConfig{
+		{
 			endpoint: "http://host.com/zones/batchrecordchanges/123",
 			code:     200,
 			body:     batchChangeJSON,
@@ -84,7 +128,7 @@ func TestBatchRecordChangeCreate(t *testing.T) {
 		t.Error(err)
 	}
 	server, client := testTools([]testToolsConfig{
-		testToolsConfig{
+		{
 			endpoint: "http://host.com/zones/batchrecordchanges",
 			code:     200,
 			body:     batchChangeCreateJSON,

--- a/vinyldns/test-fixtures/batch-changes/batch-recordchange-format.json
+++ b/vinyldns/test-fixtures/batch-changes/batch-recordchange-format.json
@@ -1,0 +1,22 @@
+{
+  "id": "id",
+  "status": "status",
+  "changeType": "changeType",
+  "recordName": "recordName",
+  "ttl": 1,
+  "type": "type",
+  "zoneName": "zoneName",
+  "inputName": "inputName",
+  "zoneID": "zoneId",
+  "totalChanges": 1,
+  "userName": "userName",
+  "comments": "comments",
+  "userId": "userId",
+  "createdTimeStamp": "createdTimeStamp",
+  "record": {
+    "address": "address",
+    "cname": "cname",
+    "ptrdname": "ptrdname"
+  },
+  "ownerGroupId": "ownerGroupId"
+}


### PR DESCRIPTION
### Description of the Change

The recordchange struct, when encoded into json, used to produce a field named "data", it now produces a field named "record"

### Why Should This Be In The Package?

The current version does not exhibit expected behavior when making batch changes.  This change resolves that.

### Benefits

Fixes a bug

### Applicable Issues

#43 
