### PR TITLE
Add GoDoc tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/vinyldns/go-vinyldns.svg?branch=master)](https://travis-ci.org/vinyldns/go-vinyldns) [![Go Report Card](https://goreportcard.com/badge/github.com/vinyldns/go-vinyldns)](https://goreportcard.com/report/github.com/vinyldns/go-vinyldns)
+[![Build Status](https://travis-ci.org/vinyldns/go-vinyldns.svg?branch=master)](https://travis-ci.org/vinyldns/go-vinyldns) [![Go Report Card](https://goreportcard.com/badge/github.com/vinyldns/go-vinyldns)](https://goreportcard.com/report/github.com/vinyldns/go-vinyldns) [![Godoc](https://godoc.org/github.com/vinyldns/go-vinyldns/vinyldns?status.svg)](https://godoc.org/github.com/vinyldns/go-vinyldns/vinyldns)
 
 # vinyldns
 


### PR DESCRIPTION
Make GoDoc docs more discoverable Closes #53

### Description of the Change

Added GoDoc tag to README.MD linking to https://godoc.org/github.com/vinyldns/go-vinyldns/vinyldns

### Why Should This Be In The Package?

Closes Issue #53

### Benefits

Makes the go-vinyldns docs more discoverable

### Possible Drawbacks

None

### Verification Process

I've tested in my fork

### Applicable Issues (Optional)

It may also be worth publishing them to gh-pages with each merge to master.