### PR TITLE
Remove reference to installing dependencies with move to go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ See `vinyldns/${resource}.go` files for the various `vinyldns` API methods.
 
 ## Development
 
-Install dependencies:
-
-```
-make deps
-```
-
 Run tests w/ code coverage:
 
 ```


### PR DESCRIPTION
### Description of the Change

Follow up to #45, updating README to remove reference to `make deps` as this directive is no longer present.

### Why Should This Be In The Package?

Update to docs