### PR TITLE
add missing fields to BatchRecordChange

### DIFF
--- a/vinyldns/batch_changes_resources.go
+++ b/vinyldns/batch_changes_resources.go
@@ -54,12 +54,19 @@ type RecordData struct {
 
 // BatchRecordChange represents a batch record change API response.
 type BatchRecordChange struct {
-	ID               string         `json:"id,omitempty"`
-	UserName         string         `json:"userName,omitempty"`
-	UserID           string         `json:"userId,omitempty"`
-	Status           string         `json:"status,omitempty"`
-	Comments         string         `json:"comments,omitempty"`
-	CreatedTimestamp string         `json:"createdTimestamp,omitempty"`
-	OwnerGroupID     string         `json:"ownerGroupId,omitempty"`
-	Changes          []RecordChange `json:"changes,omitempty"`
+	ID                 string         `json:"id,omitempty"`
+	UserName           string         `json:"userName,omitempty"`
+	UserID             string         `json:"userId,omitempty"`
+	Status             string         `json:"status,omitempty"`
+	Comments           string         `json:"comments,omitempty"`
+	CreatedTimestamp   string         `json:"createdTimestamp,omitempty"`
+	OwnerGroupID       string         `json:"ownerGroupId,omitempty"`
+	Changes            []RecordChange `json:"changes,omitempty"`
+	ApprovalStatus     string         `json:"approvalStatus,omitempty"`
+	ReviewerID         string         `json:"reviewerId,omitempty"`
+	ReviewerUserName   string         `json:"reviewerUserName,omitempty"`
+	ReviewComment      string         `json:"reviewComment,omitempty"`
+	ReviewTimestamp    string         `json:"reviewTimestamp,omitempty"`
+	ScheduledTime      string         `json:"scheduledTime,omitempty"`
+	CancelledTimestamp string         `json:"cancelledTimestamp,omitempty"`
 }


### PR DESCRIPTION
### Description of the Change

- Add missing fields in `BatchRecordChange` as per #55 
- Adhered to existing convention of representing timestamps as strings
