### PR TITLE
ensure User-Agent header is actually set

### DIFF
--- a/vinyldns/util.go
+++ b/vinyldns/util.go
@@ -46,7 +46,8 @@ func resourceRequest(c *Client, url, method string, body []byte, responseStruct 
 		return err
 	}
 
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("Content-Type", "application/json")
 
 	awsauth.Sign4(req, awsauth.Credentials{
 		AccessKeyID:     c.AccessKey,

--- a/vinyldns/util_test.go
+++ b/vinyldns/util_test.go
@@ -42,8 +42,7 @@ func TestConcatStrsWithDelimiter(t *testing.T) {
 	}
 }
 
-func TestResourceRequest(t *testing.T) {
-
+func TestResourceRequestWithDefaultUA(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.UserAgent() != defaultUA() {
 			t.Error("default user agent not set")
@@ -54,5 +53,21 @@ func TestResourceRequest(t *testing.T) {
 	c := NewClient(ClientConfiguration{Host: ts.URL})
 
 	resourceRequest(c, ts.URL, http.MethodGet, nil, nil)
+}
 
+func TestResourceRequestWithCustomUA(t *testing.T) {
+	ua := "custom-user-agent"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.UserAgent() != ua {
+			t.Error("custom user agent not set")
+		}
+	}))
+	defer ts.Close()
+
+	c := NewClient(ClientConfiguration{
+		Host:      ts.URL,
+		UserAgent: ua,
+	})
+
+	resourceRequest(c, ts.URL, http.MethodGet, nil, nil)
 }

--- a/vinyldns/util_test.go
+++ b/vinyldns/util_test.go
@@ -13,8 +13,6 @@ limitations under the License.
 package vinyldns
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -40,18 +38,4 @@ func TestConcatStrsWithDelimiter(t *testing.T) {
 	if res != "I, am, a, list" {
 		t.Error("concatStrs with delimiter failed")
 	}
-}
-
-func TestResourceRequest(t *testing.T) {
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.UserAgent() != defaultUA() {
-			t.Error("default user agent not set")
-		}
-	}))
-	defer ts.Close()
-
-	c := NewClient(ClientConfiguration{Host: ts.URL})
-
-	resourceRequest(c, ts.URL, http.MethodGet, nil, nil)
 }

--- a/vinyldns/util_test.go
+++ b/vinyldns/util_test.go
@@ -12,7 +12,11 @@ limitations under the License.
 
 package vinyldns
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestConcat(t *testing.T) {
 	res := concat([]string{"I ", "am ", "a ", "sentence"})
@@ -36,4 +40,18 @@ func TestConcatStrsWithDelimiter(t *testing.T) {
 	if res != "I, am, a, list" {
 		t.Error("concatStrs with delimiter failed")
 	}
+}
+
+func TestResourceRequest(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.UserAgent() != defaultUA() {
+			t.Error("default user agent not set")
+		}
+	}))
+	defer ts.Close()
+
+	c := NewClient(ClientConfiguration{Host: ts.URL})
+
+	resourceRequest(c, ts.URL, http.MethodGet, nil, nil)
 }

--- a/vinyldns/util_test.go
+++ b/vinyldns/util_test.go
@@ -42,8 +42,7 @@ func TestConcatStrsWithDelimiter(t *testing.T) {
 	}
 }
 
-func TestResourceRequest(t *testing.T) {
-
+func TestResourceRequestWithDefaultUA(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.UserAgent() != defaultUA() {
 			t.Error("default user agent not set")
@@ -52,6 +51,23 @@ func TestResourceRequest(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(ClientConfiguration{Host: ts.URL})
+
+	resourceRequest(c, ts.URL, http.MethodGet, nil, nil)
+}
+
+func TestResourceRequestWithCustomUA(t *testing.T) {
+	ua := "custom-user-agent"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.UserAgent() != ua {
+			t.Error("custom user agent not set")
+		}
+	}))
+	defer ts.Close()
+
+	c := NewClient(ClientConfiguration{
+		Host:      ts.URL,
+		UserAgent: ua,
+	})
 
 	resourceRequest(c, ts.URL, http.MethodGet, nil, nil)
 }

--- a/vinyldns/util_test.go
+++ b/vinyldns/util_test.go
@@ -42,7 +42,8 @@ func TestConcatStrsWithDelimiter(t *testing.T) {
 	}
 }
 
-func TestResourceRequestWithDefaultUA(t *testing.T) {
+func TestResourceRequest(t *testing.T) {
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.UserAgent() != defaultUA() {
 			t.Error("default user agent not set")
@@ -51,23 +52,6 @@ func TestResourceRequestWithDefaultUA(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(ClientConfiguration{Host: ts.URL})
-
-	resourceRequest(c, ts.URL, http.MethodGet, nil, nil)
-}
-
-func TestResourceRequestWithCustomUA(t *testing.T) {
-	ua := "custom-user-agent"
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.UserAgent() != ua {
-			t.Error("custom user agent not set")
-		}
-	}))
-	defer ts.Close()
-
-	c := NewClient(ClientConfiguration{
-		Host:      ts.URL,
-		UserAgent: ua,
-	})
 
 	resourceRequest(c, ts.URL, http.MethodGet, nil, nil)
 }


### PR DESCRIPTION
This seeks to address issue #67.

However, it appears to me that, when tested against a local VinylDNS API, VinylDNS _still_ does not log the `go-vinyldns`-set `User-Agent` header, despite that...

1. The local VinylDNS API _will_ log a custom `User-Agent` header set by other clients, such as [vinyldns-js](https://github.com/vinyldns/vinyldns-js)
2. When I use a modified version of `go-vinyldns` that issues a `Zones()` request to `http://httpbin.org/user-agent` rather than the VinylDNS API (using a technique similar to that [outlined here](https://stackoverflow.com/questions/13263492/set-useragent-in-http-request), I _do_ see the expected `{ "user-agent": "go-vinyldns/0.9.10" }` response body, thus suggesting the `User-Agent` header _is_ being sent correctly.

Am I confused or is it possible that VinylDNS dislikes some aspect of the `go-vinyldns` request and/or its `User-Agent` header?