### PR TITLE
Correct Algorithm type in Record

### DIFF
--- a/vinyldns/recordsets_resources.go
+++ b/vinyldns/recordsets_resources.go
@@ -78,7 +78,7 @@ type Record struct {
 	Weight      int    `json:"weight,omitempty"`
 	Port        int    `json:"port,omitempty"`
 	Target      string `json:"target,omitempty"`
-	Algorithm   string `json:"algorithm,omitempty"`
+	Algorithm   int    `json:"algorithm,omitempty"`
 	Type        string `json:"type,omitempty"`
 	Fingerprint string `json:"fingerprint,omitempty"`
 }


### PR DESCRIPTION
The VinylDNS API returns the algorithm field as an integer instead of a string on DS records.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Why Should This Be In The Package?

<!-- Explain why this functionality should be in the package -->
This fixes the new support for DS recordset types for DNSSEC.

### Benefits

<!-- What benefits will be realized by the code change? -->
Consumers will be able to unmarshal recordsets that include the DS type. 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

I used this modification in a separate project that consumed an large DNS Zone of great diversity in use cases without an issue.  Before it was reproducible failure, now it works fine. 

### Applicable Issues (Optional)

Fixes #71 
