### PR TITLE
add RecordSetsGlobalListAll method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=0.9.12
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
-VINYLDNS_VERSION=0.9.4
+VINYLDNS_VERSION=0.9.5
 
 all: check-fmt test build integration stop-api validate-version install
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=0.9.12
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
-VINYLDNS_VERSION=0.9.3
+VINYLDNS_VERSION=0.9.4
 
 all: check-fmt test build integration stop-api validate-version install
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.12
+VERSION=0.9.13
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
 VINYLDNS_VERSION=0.9.5

--- a/vinyldns/endpoints.go
+++ b/vinyldns/endpoints.go
@@ -55,6 +55,13 @@ func recordSetsListEP(c *Client, zoneID string, f ListFilter) string {
 	return concatStrs("", recordSetsEP(c, zoneID), query)
 }
 
+func recordSetsGlobalListEP(c *Client, f GlobalListFilter) string {
+	query := buildGlobalListQuery(f)
+	base := concatStrs("", c.Host, "/recordsets")
+
+	return concatStrs("", base, query)
+}
+
 func recordSetEP(c *Client, zoneID, recordSetID string) string {
 	return concatStrs("", recordSetsEP(c, zoneID), "/", recordSetID)
 }
@@ -109,6 +116,41 @@ func buildQuery(f ListFilter, nameFilterName string) string {
 
 	if f.NameFilter != "" {
 		params = append(params, fmt.Sprintf("%s=%s", nameFilterName, f.NameFilter))
+	}
+
+	if f.StartFrom != "" {
+		params = append(params, fmt.Sprintf("startFrom=%s", f.StartFrom))
+	}
+
+	if f.MaxItems != 0 {
+		params = append(params, fmt.Sprintf("maxItems=%d", f.MaxItems))
+	}
+
+	if len(params) == 0 {
+		query = ""
+	}
+
+	return query + strings.Join(params, "&")
+}
+
+func buildGlobalListQuery(f GlobalListFilter) string {
+	params := []string{}
+	query := "?"
+
+	if f.RecordNameFilter != "" {
+		params = append(params, fmt.Sprintf("%s=%s", "recordNameFilter", f.RecordNameFilter))
+	}
+
+	if f.RecordTypeFilter != "" {
+		params = append(params, fmt.Sprintf("%s=%s", "recordTypeFilter", f.RecordTypeFilter))
+	}
+
+	if f.RecordOwnerGroupFilter != "" {
+		params = append(params, fmt.Sprintf("%s=%s", "recordOwnerGroupFilter", f.RecordOwnerGroupFilter))
+	}
+
+	if f.NameSort != "" {
+		params = append(params, fmt.Sprintf("%s=%s", "nameSort", f.NameSort))
 	}
 
 	if f.StartFrom != "" {

--- a/vinyldns/endpoints_test.go
+++ b/vinyldns/endpoints_test.go
@@ -167,6 +167,54 @@ func TestRecordSetsListEP(t *testing.T) {
 	}
 }
 
+func TestRecordSetsGlobalListEP(t *testing.T) {
+	rs := recordSetsGlobalListEP(c, GlobalListFilter{})
+	expected := "http://host.com/recordsets"
+	msg := "recordSetsGlobalListEP should return the right endpoint"
+
+	if rs != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", rs)
+		t.Error(msg)
+	}
+
+	rs = recordSetsGlobalListEP(c, GlobalListFilter{
+		StartFrom: "nextplease",
+	})
+	expected = "http://host.com/recordsets?startFrom=nextplease"
+
+	if rs != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", rs)
+		t.Error(msg)
+	}
+
+	rs = recordSetsGlobalListEP(c, GlobalListFilter{
+		StartFrom: "nextplease",
+		MaxItems:  99,
+	})
+	expected = "http://host.com/recordsets?startFrom=nextplease&maxItems=99"
+
+	if rs != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", rs)
+		t.Error(msg)
+	}
+
+	rs = recordSetsGlobalListEP(c, GlobalListFilter{
+		RecordNameFilter: "foo",
+		StartFrom:        "nextplease",
+		MaxItems:         99,
+	})
+	expected = "http://host.com/recordsets?recordNameFilter=foo&startFrom=nextplease&maxItems=99"
+
+	if rs != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", rs)
+		t.Error(msg)
+	}
+}
+
 func TestRecordSetEP(t *testing.T) {
 	rs := recordSetEP(c, "123", "456")
 	expected := "http://host.com/zones/123/recordsets/456"
@@ -352,5 +400,30 @@ func TestBuildQueryWithNoQuery(t *testing.T) {
 		fmt.Printf("Expected: %s", expected)
 		fmt.Printf("Actual: %s", query)
 		t.Error("buildQuery should return the right string")
+	}
+}
+
+func TestBuildGlobalListQuery(t *testing.T) {
+	query := buildGlobalListQuery(GlobalListFilter{
+		MaxItems:         1,
+		RecordNameFilter: "foo",
+	})
+	expected := "?recordNameFilter=foo&maxItems=1"
+
+	if query != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", query)
+		t.Error("buildGlobalListQuery should return the right string")
+	}
+}
+
+func TestBuildGlobalListQueryWithNoQuery(t *testing.T) {
+	query := buildGlobalListQuery(GlobalListFilter{})
+	expected := ""
+
+	if query != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", query)
+		t.Error("buildGlobalListQuery should return the right string")
 	}
 }

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -421,7 +421,7 @@ func TestRecordSetsGlobalListAllIntegrationFilterForExistentName(t *testing.T) {
 	}
 
 	records, err := c.RecordSetsGlobalListAll(GlobalListFilter{
-		RecordNameFilter: rName,
+		RecordNameFilter: rName + "*",
 	})
 	if err != nil {
 		t.Error(err)

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -399,15 +399,36 @@ func TestRecordSetsListAllIntegrationFilterForNonexistentName(t *testing.T) {
 
 func TestRecordSetsGlobalListAllIntegrationFilterForExistentName(t *testing.T) {
 	c := client()
+	rName := "global-list-int-test"
+	zs, err := c.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = c.RecordSetCreate(&RecordSet{
+		Name:   rName,
+		ZoneID: zs[0].ID,
+		Type:   "A",
+		TTL:    60,
+		Records: []Record{
+			{
+				Address: "127.0.0.1",
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
 	records, err := c.RecordSetsGlobalListAll(GlobalListFilter{
-		RecordNameFilter: "foo",
+		RecordNameFilter: rName,
 	})
 	if err != nil {
 		t.Error(err)
 	}
 
 	if len(records) < 1 {
-		t.Error("Expected RecordSetsGlobalListAll for records named 'foo' to yield results")
+		t.Error(fmt.Sprintf("Expected RecordSetsGlobalListAll for records named '%s' to yield results", rName))
 	}
 }
 

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -399,29 +399,10 @@ func TestRecordSetsListAllIntegrationFilterForNonexistentName(t *testing.T) {
 
 func TestRecordSetsGlobalListAllIntegrationFilterForExistentName(t *testing.T) {
 	c := client()
-	rName := "global-list-int-test"
-	zs, err := c.ZonesListAll(ListFilter{})
-	if err != nil {
-		t.Error(err)
-	}
-
-	_, err = c.RecordSetCreate(&RecordSet{
-		Name:   rName,
-		ZoneID: zs[0].ID,
-		Type:   "A",
-		TTL:    60,
-		Records: []Record{
-			{
-				Address: "127.0.0.1",
-			},
-		},
-	})
-	if err != nil {
-		t.Error(err)
-	}
+	rName := "foo"
 
 	records, err := c.RecordSetsGlobalListAll(GlobalListFilter{
-		RecordNameFilter: rName + "*",
+		RecordNameFilter: "*" + rName + "*",
 	})
 	if err != nil {
 		t.Error(err)

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -430,6 +430,10 @@ func TestRecordSetsGlobalListAllIntegrationFilterForExistentName(t *testing.T) {
 	if len(records) < 1 {
 		t.Error(fmt.Sprintf("Expected RecordSetsGlobalListAll for records named '%s' to yield results", rName))
 	}
+
+	if records[0].Name != rName {
+		t.Error(fmt.Sprintf("Expected RecordSetsGlobalListAll for records named '%s' to return the matching record", rName))
+	}
 }
 
 func TestRecordSetsGlobalListAllIntegrationFilterForNonexistentName(t *testing.T) {

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -397,6 +397,34 @@ func TestRecordSetsListAllIntegrationFilterForNonexistentName(t *testing.T) {
 	}
 }
 
+func TestRecordSetsGlobalListAllIntegrationFilterForExistentName(t *testing.T) {
+	c := client()
+	records, err := c.RecordSetsGlobalListAll(GlobalListFilter{
+		RecordNameFilter: "foo",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(records) < 1 {
+		t.Error("Expected RecordSetsGlobalListAll for records named 'foo' to yield results")
+	}
+}
+
+func TestRecordSetsGlobalListAllIntegrationFilterForNonexistentName(t *testing.T) {
+	c := client()
+	records, err := c.RecordSetsGlobalListAll(GlobalListFilter{
+		RecordNameFilter: "thisdoesnotexist",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(records) > 0 {
+		t.Error("Expected RecordSetsListAll for records named 'thisdoesnotexist' to yield no results")
+	}
+}
+
 func TestRecordSetDeleteIntegration(t *testing.T) {
 	c := client()
 	zs, err := c.ZonesListAll(ListFilter{})

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -91,8 +91,9 @@ func (c *Client) RecordSets(id string) ([]RecordSet, error) {
 	return recordSets, nil
 }
 
-// RecordSetsListAll retrieves the complete list of record sets with the ListFilter criteria passed.
-// Handles paging through results on the user's behalf.
+// RecordSetsListAll retrieves the complete list of record sets from
+// the specified zone with the ListFilter criteria passed.
+// It handles paging through results on the user's behalf.
 func (c *Client) RecordSetsListAll(zoneID string, filter ListFilter) ([]RecordSet, error) {
 	if filter.MaxItems > 100 {
 		return nil, fmt.Errorf("MaxItems must be between 1 and 100")
@@ -117,7 +118,7 @@ func (c *Client) RecordSetsListAll(zoneID string, filter ListFilter) ([]RecordSe
 
 // RecordSetsGlobalListAll retrieves the complete list of record sets with the
 // GlobalListFilter criteria passed, across all zones.
-// Handles paging through results on the user's behalf.
+// It handles paging through results on the user's behalf.
 func (c *Client) RecordSetsGlobalListAll(filter GlobalListFilter) ([]RecordSet, error) {
 	if filter.MaxItems > 100 {
 		return nil, fmt.Errorf("MaxItems must be between 1 and 100")

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -115,6 +115,31 @@ func (c *Client) RecordSetsListAll(zoneID string, filter ListFilter) ([]RecordSe
 	}
 }
 
+// RecordSetsGlobalListAll retrieves the complete list of record sets with the
+// GlobalListFilter criteria passed, across all zones.
+// Handles paging through results on the user's behalf.
+func (c *Client) RecordSetsGlobalListAll(filter GlobalListFilter) ([]RecordSet, error) {
+	if filter.MaxItems > 100 {
+		return nil, fmt.Errorf("MaxItems must be between 1 and 100")
+	}
+
+	rss := []RecordSet{}
+
+	for {
+		resp, err := c.recordSetsGlobalList(filter)
+		if err != nil {
+			return nil, err
+		}
+
+		rss = append(rss, resp.RecordSets...)
+		filter.StartFrom = resp.NextID
+
+		if len(filter.StartFrom) == 0 {
+			return rss, nil
+		}
+	}
+}
+
 // RecordSet retrieves the record matching the Zone ID and RecordSet ID it's passed.
 func (c *Client) RecordSet(zoneID, recordSetID string) (RecordSet, error) {
 	rs := &RecordSetResponse{}

--- a/vinyldns/recordsets_helpers.go
+++ b/vinyldns/recordsets_helpers.go
@@ -12,10 +12,23 @@ limitations under the License.
 
 package vinyldns
 
-// recordSetsList retrieves the list of record sets with the List criteria passed.
+// recordSetsList retrieves the list of record sets with the List criteria passed,
+// for the specified zone.
 func (c *Client) recordSetsList(zoneID string, filter ListFilter) (*RecordSetsResponse, error) {
 	recordSets := &RecordSetsResponse{}
 	err := resourceRequest(c, recordSetsListEP(c, zoneID, filter), "GET", nil, recordSets)
+	if err != nil {
+		return recordSets, err
+	}
+
+	return recordSets, nil
+}
+
+// recordSetsGlobalList retrieves the list of record sets with the List criteria passed,
+// across all zones.
+func (c *Client) recordSetsGlobalList(filter GlobalListFilter) (*RecordSetsResponse, error) {
+	recordSets := &RecordSetsResponse{}
+	err := resourceRequest(c, recordSetsGlobalListEP(c, filter), "GET", nil, recordSets)
 	if err != nil {
 		return recordSets, err
 	}

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -43,9 +43,32 @@ func (d Error) Error() string {
 }
 
 // ListFilter represents the list query parameters that may be passed to
-// VinylDNS API endpoints such as /zones and /recordsets
+// VinylDNS API endpoints such as /zones and /zones/${zone_id}/recordsets
 type ListFilter struct {
 	NameFilter string
 	StartFrom  string
 	MaxItems   int
+}
+
+// NameSort specifies the name sort order for record sets returned by the global list record set response.
+// Valid values are ASC (ascending; default) and DESC (descending).
+type NameSort string
+
+const (
+	// ASC represents an ascending NameSort
+	ASC NameSort = "ASC"
+
+	// DESC represents a descending NameSort
+	DESC NameSort = "DESC"
+)
+
+// GlobalListFilter represents the list query parameters that may be passed to
+// VinylDNS API endpoints such as /recordsets
+type GlobalListFilter struct {
+	RecordNameFilter       string
+	RecordTypeFilter       string
+	RecordOwnerGroupFilter string
+	NameSort               NameSort
+	StartFrom              string
+	MaxItems               int
 }

--- a/vinyldns/version.go
+++ b/vinyldns/version.go
@@ -13,4 +13,4 @@ limitations under the License.
 package vinyldns
 
 // Version stores the go-vinyldns semantic version
-var Version = "0.9.12"
+var Version = "0.9.13"


### PR DESCRIPTION
While oddly named, this method interacts with the
[global list recordsets](https://www.vinyldns.io/api/list-recordsets-global.html)
endpoint (as opposed to the `RecordSetsListAll` method, which
lists record sets within the specified zone).

This seeks to address issue #75 