### PR TITLE
Update dependencies to use Go 1.21 & support VinylDNS 0.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ VERSION=0.9.16
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
 VINYLDNS_DIR="$(GOPATH)/src/$(VINYLDNS_REPO)/" 
+VINYLDNS_VERSION=latest
 
 ifndef $(GOPATH)
     GOPATH=$(shell go env GOPATH)
@@ -38,7 +39,7 @@ clonevinyl:
 
 start-api: clonevinyl stop-api
 	$(GOPATH)/src/$(VINYLDNS_REPO)/quickstart/quickstart-vinyldns.sh \
-		--api
+		--api --version-tag $(VINYLDNS_VERSION)
 
 stop-api:
 	$(GOPATH)/src/$(VINYLDNS_REPO)/quickstart/quickstart-vinyldns.sh \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ integration: start-api
 validate-version:
 	cat vinyldns/version.go | grep 'var Version = "$(VERSION)"'
 
-clonevinyl:
+clone-vinyl:
 	if [ ! -d  $(VINYLDNS_DIR) ]; then \
 		echo "$(VINYLDNS_REPO) not found in your GOPATH (necessary for acceptance tests), getting..."; \
 		git clone \
@@ -37,7 +37,7 @@ clonevinyl:
 		git -C $(VINYLDNS_DIR) pull ; \
 	fi
 
-start-api: clonevinyl stop-api
+start-api: clone-vinyl stop-api
 	$(GOPATH)/src/$(VINYLDNS_REPO)/quickstart/quickstart-vinyldns.sh \
 		--api --version-tag $(VINYLDNS_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=0.9.16
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
-VINYLDNS_VERSION=0.20.0
+VINYLDNS_DIR="$(GOPATH)/src/$(VINYLDNS_REPO)/" 
 
 ifndef $(GOPATH)
     GOPATH=$(shell go env GOPATH)
@@ -20,26 +20,28 @@ test:
 	go vet $(SOURCE)
 	GO111MODULE=on go test $(SOURCE) -cover
 
-integration: stop-api start-api
+integration: start-api
 	GO111MODULE=on go test $(SOURCE) -tags=integration
 
 validate-version:
 	cat vinyldns/version.go | grep 'var Version = "$(VERSION)"'
 
-start-api:
-	if [ ! -d "$(GOPATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)" ]; then \
-		echo "$(VINYLDNS_REPO)-$(VINYLDNS_VERSION) not found in your GOPATH (necessary for acceptance tests), getting..."; \
+clonevinyl:
+	if [ ! -d  $(VINYLDNS_DIR) ]; then \
+		echo "$(VINYLDNS_REPO) not found in your GOPATH (necessary for acceptance tests), getting..."; \
 		git clone \
-			--branch v$(VINYLDNS_VERSION) \
 			https://$(VINYLDNS_REPO) \
-			$(GOPATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION); \
+			$(VINYLDNS_DIR); \
+	else \
+		git -C $(VINYLDNS_DIR) pull ; \
 	fi
-	$(GOPATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/quickstart/quickstart-vinyldns.sh \
-		--api \
-		--version-tag $(VINYLDNS_VERSION)
+
+start-api: clonevinyl stop-api
+	$(GOPATH)/src/$(VINYLDNS_REPO)/quickstart/quickstart-vinyldns.sh \
+		--api
 
 stop-api:
-	$(GOPATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/quickstart/quickstart-vinyldns.sh \
+	$(GOPATH)/src/$(VINYLDNS_REPO)/quickstart/quickstart-vinyldns.sh \
 		--clean
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=0.9.16
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
-VINYLDNS_VERSION=0.9.10
+VINYLDNS_VERSION=0.20.0
 
 ifndef $(GOPATH)
     GOPATH=$(shell go env GOPATH)
@@ -20,7 +20,7 @@ test:
 	go vet $(SOURCE)
 	GO111MODULE=on go test $(SOURCE) -cover
 
-integration: start-api
+integration: stop-api start-api
 	GO111MODULE=on go test $(SOURCE) -tags=integration
 
 validate-version:
@@ -34,12 +34,13 @@ start-api:
 			https://$(VINYLDNS_REPO) \
 			$(GOPATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION); \
 	fi
-	$(GOPATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/bin/docker-up-vinyldns.sh \
-		--api-only \
-		--version $(VINYLDNS_VERSION)
+	$(GOPATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/quickstart/quickstart-vinyldns.sh \
+		--api \
+		--version-tag $(VINYLDNS_VERSION)
 
 stop-api:
-	$(GOPATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/bin/remove-vinyl-containers.sh
+	$(GOPATH)/src/$(VINYLDNS_REPO)-$(VINYLDNS_VERSION)/quickstart/quickstart-vinyldns.sh \
+		--clean
 
 build:
 	GO111MODULE=on go build -ldflags "-X main.version=$(VERSION)" $(SOURCE)

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/vinyldns/go-vinyldns
 
-go 1.17
+go 1.21
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.26.1
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.11
 	github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b
-	github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9
-	github.com/smartystreets/gunit v1.0.4 // indirect
 )
+
+require github.com/aws/smithy-go v1.20.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
+github.com/aws/aws-sdk-go-v2 v1.26.1 h1:5554eUqIYVWpU0YmeeYZ0wU64H2VLBs8TlhRB2L+EkA=
+github.com/aws/aws-sdk-go-v2 v1.26.1/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
+github.com/aws/aws-sdk-go-v2/credentials v1.17.11 h1:YuIB1dJNf1Re822rriUOTxopaHHvIq0l/pX3fwO+Tzs=
+github.com/aws/aws-sdk-go-v2/credentials v1.17.11/go.mod h1:AQtFPsDH9bI2O+71anW6EKL+NcD7LG3dpKGMV4SShgo=
+github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
+github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
 github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b h1:/vQ+oYKu+JoyaMPDsv5FzwuL2wwWBgBbtj/YLCi4LuA=
 github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b/go.mod h1:Xo4aNUOrJnVruqWQJBtW6+bTBDTniY8yZum5rF3b5jw=
-github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=
-github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
-github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9 h1:hp2CYQUINdZMHdvTdXtPOY2ainKl4IoMcpAXEf2xj3Q=
-github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
-github.com/smartystreets/gunit v1.0.4 h1:tpTjnuH7MLlqhoD21vRoMZbMIi5GmBsAJDFyF67GhZA=
-github.com/smartystreets/gunit v1.0.4/go.mod h1:EH5qMBab2UclzXUcpR8b93eHsIlp9u+pDQIRp5DZNzQ=

--- a/vinyldns/endpoints.go
+++ b/vinyldns/endpoints.go
@@ -66,8 +66,8 @@ func recordSetEP(c *Client, zoneID, recordSetID string) string {
 	return concatStrs("", recordSetsEP(c, zoneID), "/", recordSetID)
 }
 
-func recordSetChangesEP(c *Client, zoneID string, f ListFilter) string {
-	query := buildQuery(f, "nameFilter")
+func recordSetChangesEP(c *Client, zoneID string, f ListFilterInt) string {
+	query := buildQueryInt(f, "nameFilter")
 
 	return concatStrs("", zoneEP(c, zoneID), "/recordsetchanges", query)
 }
@@ -120,6 +120,29 @@ func buildQuery(f ListFilter, nameFilterName string) string {
 
 	if f.StartFrom != "" {
 		params = append(params, fmt.Sprintf("startFrom=%s", f.StartFrom))
+	}
+
+	if f.MaxItems != 0 {
+		params = append(params, fmt.Sprintf("maxItems=%d", f.MaxItems))
+	}
+
+	if len(params) == 0 {
+		query = ""
+	}
+
+	return query + strings.Join(params, "&")
+}
+
+func buildQueryInt(f ListFilterInt, nameFilterName string) string {
+	params := []string{}
+	query := "?"
+
+	if f.NameFilter != "" {
+		params = append(params, fmt.Sprintf("%s=%s", nameFilterName, f.NameFilter))
+	}
+
+	if f.StartFrom != 0 {
+		params = append(params, fmt.Sprintf("startFrom=%d", f.StartFrom))
 	}
 
 	if f.MaxItems != 0 {

--- a/vinyldns/endpoints.go
+++ b/vinyldns/endpoints.go
@@ -66,8 +66,8 @@ func recordSetEP(c *Client, zoneID, recordSetID string) string {
 	return concatStrs("", recordSetsEP(c, zoneID), "/", recordSetID)
 }
 
-func recordSetChangesEP(c *Client, zoneID string, f ListFilterInt) string {
-	query := buildQueryInt(f, "nameFilter")
+func recordSetChangesEP(c *Client, zoneID string, f ListFilterRecordSetChanges) string {
+	query := buildRecordSetChangesQuery(f)
 
 	return concatStrs("", zoneEP(c, zoneID), "/recordsetchanges", query)
 }
@@ -133,13 +133,9 @@ func buildQuery(f ListFilter, nameFilterName string) string {
 	return query + strings.Join(params, "&")
 }
 
-func buildQueryInt(f ListFilterInt, nameFilterName string) string {
+func buildRecordSetChangesQuery(f ListFilterRecordSetChanges) string {
 	params := []string{}
 	query := "?"
-
-	if f.NameFilter != "" {
-		params = append(params, fmt.Sprintf("%s=%s", nameFilterName, f.NameFilter))
-	}
 
 	if f.StartFrom != 0 {
 		params = append(params, fmt.Sprintf("startFrom=%d", f.StartFrom))

--- a/vinyldns/endpoints_test.go
+++ b/vinyldns/endpoints_test.go
@@ -227,7 +227,7 @@ func TestRecordSetEP(t *testing.T) {
 }
 
 func TestRecordSetChangesEP(t *testing.T) {
-	rsc := recordSetChangesEP(c, "123", ListFilter{})
+	rsc := recordSetChangesEP(c, "123", ListFilterInt{})
 	expected := "http://host.com/zones/123/recordsetchanges"
 
 	if rsc != expected {
@@ -238,9 +238,9 @@ func TestRecordSetChangesEP(t *testing.T) {
 }
 
 func TestRecordSetChangesEPWithQuery(t *testing.T) {
-	rsc := recordSetChangesEP(c, "123", ListFilter{
+	rsc := recordSetChangesEP(c, "123", ListFilterInt{
 		MaxItems:  3,
-		StartFrom: "1",
+		StartFrom: 1,
 	})
 	expected := "http://host.com/zones/123/recordsetchanges?startFrom=1&maxItems=3"
 

--- a/vinyldns/endpoints_test.go
+++ b/vinyldns/endpoints_test.go
@@ -227,7 +227,7 @@ func TestRecordSetEP(t *testing.T) {
 }
 
 func TestRecordSetChangesEP(t *testing.T) {
-	rsc := recordSetChangesEP(c, "123", ListFilterInt{})
+	rsc := recordSetChangesEP(c, "123", ListFilterRecordSetChanges{})
 	expected := "http://host.com/zones/123/recordsetchanges"
 
 	if rsc != expected {
@@ -238,7 +238,7 @@ func TestRecordSetChangesEP(t *testing.T) {
 }
 
 func TestRecordSetChangesEPWithQuery(t *testing.T) {
-	rsc := recordSetChangesEP(c, "123", ListFilterInt{
+	rsc := recordSetChangesEP(c, "123", ListFilterRecordSetChanges{
 		MaxItems:  3,
 		StartFrom: 1,
 	})

--- a/vinyldns/groups_test.go
+++ b/vinyldns/groups_test.go
@@ -182,7 +182,7 @@ func TestGroupsListAll(t *testing.T) {
 			body:     groupsListJSON1,
 		},
 		{
-			endpoint: "http://host.com/groups?startFrom=2&maxItems=1",
+			endpoint: "http://host.com/groups?maxItems=1&startFrom=2",
 			code:     200,
 			body:     groupsListJSON2,
 		},

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -466,7 +466,7 @@ func TestRecordSetChangesIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
-	changes, err := c.RecordSetChanges(zones[0].ID, ListFilterInt{})
+	changes, err := c.RecordSetChanges(zones[0].ID, ListFilterRecordSetChanges{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -483,7 +483,7 @@ func TestRecordSetChangesIntegrationWithMaxItems(t *testing.T) {
 		t.Error(err)
 	}
 
-	changes, err := c.RecordSetChanges(zones[0].ID, ListFilterInt{
+	changes, err := c.RecordSetChanges(zones[0].ID, ListFilterRecordSetChanges{
 		MaxItems: 1,
 	})
 	if err != nil {
@@ -502,7 +502,7 @@ func TestRecordSetChangesListAllIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
-	changes, err := c.RecordSetChangesListAll(zones[0].ID, ListFilterInt{})
+	changes, err := c.RecordSetChangesListAll(zones[0].ID, ListFilterRecordSetChanges{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -46,7 +46,7 @@ func TestGroupCreateIntegration(t *testing.T) {
 	gc, err := c.GroupCreate(&Group{
 		Name:        "test-group",
 		Description: "a test group",
-		Email:       "test@vinyldns.com",
+		Email:       "test@test.com",
 		Admins:      users,
 		Members:     users,
 	})
@@ -91,7 +91,7 @@ func TestGroupAdminsIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
-	if admins[0].UserName != "ok" {
+	if admins[0].UserName != "ok" && admins[0].UserName != "dummy" {
 		t.Error(fmt.Sprintf("unable to get group admins for group %s", gID))
 	}
 }
@@ -117,12 +117,12 @@ func TestZoneCreateIntegration(t *testing.T) {
 		Name:          "ok.",
 		KeyName:       "vinyldns.",
 		Key:           "nzisn+4G2ldMn0q1CV3vsg==",
-		PrimaryServer: "vinyldns-bind9",
+		PrimaryServer: "vinyldns-integration:19001",
 	}
 
 	zone := &Zone{
 		Name:               "ok.",
-		Email:              "email@email.com",
+		Email:              "email@test.com",
 		AdminGroupID:       groups[0].ID,
 		Connection:         connection,
 		TransferConnection: connection,
@@ -403,7 +403,7 @@ func TestRecordSetsGlobalListAllIntegrationFilterForExistentName(t *testing.T) {
 	rName := "foo"
 
 	records, err := c.RecordSetsGlobalListAll(GlobalListFilter{
-		RecordNameFilter: "*" + rName + "*",
+		RecordNameFilter: rName + "*",
 	})
 	if err != nil {
 		t.Error(err)
@@ -466,7 +466,7 @@ func TestRecordSetChangesIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
-	changes, err := c.RecordSetChanges(zones[0].ID, ListFilter{})
+	changes, err := c.RecordSetChanges(zones[0].ID, ListFilterInt{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -483,7 +483,7 @@ func TestRecordSetChangesIntegrationWithMaxItems(t *testing.T) {
 		t.Error(err)
 	}
 
-	changes, err := c.RecordSetChanges(zones[0].ID, ListFilter{
+	changes, err := c.RecordSetChanges(zones[0].ID, ListFilterInt{
 		MaxItems: 1,
 	})
 	if err != nil {
@@ -502,7 +502,7 @@ func TestRecordSetChangesListAllIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
-	changes, err := c.RecordSetChangesListAll(zones[0].ID, ListFilter{})
+	changes, err := c.RecordSetChangesListAll(zones[0].ID, ListFilterInt{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/vinyldns/mock_testing_server_test.go
+++ b/vinyldns/mock_testing_server_test.go
@@ -15,10 +15,10 @@ package vinyldns
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 )
 
 type testToolsConfig struct {
@@ -28,7 +28,7 @@ type testToolsConfig struct {
 }
 
 func readFile(file string) (string, error) {
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -209,7 +209,7 @@ func (c *Client) RecordSetDelete(zoneID, recordSetID string) (*RecordSetUpdateRe
 }
 
 // RecordSetChanges retrieves the RecordSetChanges response for the Zone and ListFilter it's passed.
-func (c *Client) RecordSetChanges(zoneID string, f ListFilterInt) (*RecordSetChanges, error) {
+func (c *Client) RecordSetChanges(zoneID string, f ListFilterRecordSetChanges) (*RecordSetChanges, error) {
 	rsc := &RecordSetChanges{}
 	err := resourceRequest(c, recordSetChangesEP(c, zoneID, f), "GET", nil, rsc)
 	if err != nil {
@@ -221,7 +221,7 @@ func (c *Client) RecordSetChanges(zoneID string, f ListFilterInt) (*RecordSetCha
 
 // RecordSetChangesListAll retrieves the complete list of record set changes for the Zone ListFilter criteria passed.
 // Handles paging through results on the user's behalf.
-func (c *Client) RecordSetChangesListAll(zoneID string, filter ListFilterInt) ([]RecordSetChange, error) {
+func (c *Client) RecordSetChangesListAll(zoneID string, filter ListFilterRecordSetChanges) ([]RecordSetChange, error) {
 	if filter.MaxItems > 100 {
 		return nil, fmt.Errorf("MaxItems must be between 1 and 100")
 	}

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -209,7 +209,7 @@ func (c *Client) RecordSetDelete(zoneID, recordSetID string) (*RecordSetUpdateRe
 }
 
 // RecordSetChanges retrieves the RecordSetChanges response for the Zone and ListFilter it's passed.
-func (c *Client) RecordSetChanges(zoneID string, f ListFilter) (*RecordSetChanges, error) {
+func (c *Client) RecordSetChanges(zoneID string, f ListFilterInt) (*RecordSetChanges, error) {
 	rsc := &RecordSetChanges{}
 	err := resourceRequest(c, recordSetChangesEP(c, zoneID, f), "GET", nil, rsc)
 	if err != nil {
@@ -221,7 +221,7 @@ func (c *Client) RecordSetChanges(zoneID string, f ListFilter) (*RecordSetChange
 
 // RecordSetChangesListAll retrieves the complete list of record set changes for the Zone ListFilter criteria passed.
 // Handles paging through results on the user's behalf.
-func (c *Client) RecordSetChangesListAll(zoneID string, filter ListFilter) ([]RecordSetChange, error) {
+func (c *Client) RecordSetChangesListAll(zoneID string, filter ListFilterInt) ([]RecordSetChange, error) {
 	if filter.MaxItems > 100 {
 		return nil, fmt.Errorf("MaxItems must be between 1 and 100")
 	}
@@ -237,7 +237,7 @@ func (c *Client) RecordSetChangesListAll(zoneID string, filter ListFilter) ([]Re
 		rsc = append(rsc, resp.RecordSetChanges...)
 		filter.StartFrom = resp.NextID
 
-		if len(filter.StartFrom) == 0 {
+		if filter.StartFrom == 0 {
 			return rsc, nil
 		}
 	}

--- a/vinyldns/recordsets_resources.go
+++ b/vinyldns/recordsets_resources.go
@@ -28,7 +28,7 @@ type RecordSetChange struct {
 type RecordSetChanges struct {
 	RecordSetChanges []RecordSetChange `json:"recordSetChanges"`
 	ZoneID           string            `json:"zoneId,omitempty"`
-	StartFrom        any               `json:"startFrom,omitempty"`
+	StartFrom        int               `json:"startFrom,omitempty"`
 	NextID           int               `json:"nextId,omitempty"`
 	MaxItems         int               `json:"maxItems,omitempty"`
 	Status           string            `json:"status,omitempty"`

--- a/vinyldns/recordsets_resources.go
+++ b/vinyldns/recordsets_resources.go
@@ -28,8 +28,8 @@ type RecordSetChange struct {
 type RecordSetChanges struct {
 	RecordSetChanges []RecordSetChange `json:"recordSetChanges"`
 	ZoneID           string            `json:"zoneId,omitempty"`
-	StartFrom        string            `json:"startFrom,omitempty"`
-	NextID           string            `json:"nextId,omitempty"`
+	StartFrom        any               `json:"startFrom,omitempty"`
+	NextID           int               `json:"nextId,omitempty"`
 	MaxItems         int               `json:"maxItems,omitempty"`
 	Status           string            `json:"status,omitempty"`
 }

--- a/vinyldns/recordsets_test.go
+++ b/vinyldns/recordsets_test.go
@@ -65,7 +65,7 @@ func TestRecordSetsListAll(t *testing.T) {
 			body:     recordSetsListJSON1,
 		},
 		{
-			endpoint: "http://host.com/zones/123/recordsets?startFrom=2&maxItems=1",
+			endpoint: "http://host.com/zones/123/recordsets?maxItems=1&startFrom=2",
 			code:     200,
 			body:     recordSetsListJSON2,
 		},
@@ -149,7 +149,7 @@ func TestRecordSetsGlobalListAll(t *testing.T) {
 			body:     recordSetsListJSON1,
 		},
 		{
-			endpoint: "http://host.com/recordsets?startFrom=2&maxItems=1",
+			endpoint: "http://host.com/recordsets?maxItems=1&startFrom=2",
 			code:     200,
 			body:     recordSetsListJSON2,
 		},
@@ -513,7 +513,7 @@ func TestRecordSetChangessListAllWhenNoneExist(t *testing.T) {
 
 	defer server.Close()
 
-	changes, err := client.RecordSetChangesListAll("123", ListFilter{})
+	changes, err := client.RecordSetChangesListAll("123", ListFilterInt{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -548,7 +548,7 @@ func TestRecordSetChangesListAll(t *testing.T) {
 			body:     recordSetChangesJSON1,
 		},
 		{
-			endpoint: "http://host.com/zones/123/recordsetchanges?startFrom=2&maxItems=1",
+			endpoint: "http://host.com/zones/123/recordsetchanges?maxItems=1&startFrom=2",
 			code:     200,
 			body:     recordSetChangesJSON2,
 		},
@@ -556,13 +556,13 @@ func TestRecordSetChangesListAll(t *testing.T) {
 
 	defer server.Close()
 
-	if _, err := client.RecordSetChangesListAll("123", ListFilter{
+	if _, err := client.RecordSetChangesListAll("123", ListFilterInt{
 		MaxItems: 200,
 	}); err == nil {
 		t.Error("Expected error -- MaxItems must be between 1 and 100")
 	}
 
-	changes, err := client.RecordSetChangesListAll("123", ListFilter{
+	changes, err := client.RecordSetChangesListAll("123", ListFilterInt{
 		MaxItems: 1,
 	})
 	if err != nil {

--- a/vinyldns/recordsets_test.go
+++ b/vinyldns/recordsets_test.go
@@ -513,7 +513,7 @@ func TestRecordSetChangessListAllWhenNoneExist(t *testing.T) {
 
 	defer server.Close()
 
-	changes, err := client.RecordSetChangesListAll("123", ListFilterInt{})
+	changes, err := client.RecordSetChangesListAll("123", ListFilterRecordSetChanges{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -556,13 +556,13 @@ func TestRecordSetChangesListAll(t *testing.T) {
 
 	defer server.Close()
 
-	if _, err := client.RecordSetChangesListAll("123", ListFilterInt{
+	if _, err := client.RecordSetChangesListAll("123", ListFilterRecordSetChanges{
 		MaxItems: 200,
 	}); err == nil {
 		t.Error("Expected error -- MaxItems must be between 1 and 100")
 	}
 
-	changes, err := client.RecordSetChangesListAll("123", ListFilterInt{
+	changes, err := client.RecordSetChangesListAll("123", ListFilterRecordSetChanges{
 		MaxItems: 1,
 	})
 	if err != nil {

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -50,13 +50,11 @@ type ListFilter struct {
 	MaxItems   int
 }
 
-// ListFilterInt represents the list query parameters that may be passed to
-// VinylDNS API endpoints such as /zones and /zones/${zone_id}/recordsets
-// Same as ListFilter except for resources where StartFrom is an int instead of string
-type ListFilterInt struct {
-	NameFilter string
-	StartFrom  int
-	MaxItems   int
+// ListFilterRecordSetChanges represents the list query parameters that may be passed to
+// VinylDNS API endpoint /zones/${zone_id}/recordsetchanges
+type ListFilterRecordSetChanges struct {
+	StartFrom int
+	MaxItems  int
 }
 
 // NameSort specifies the name sort order for record sets returned by the global list record set response.

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -50,6 +50,15 @@ type ListFilter struct {
 	MaxItems   int
 }
 
+// ListFilterInt represents the list query parameters that may be passed to
+// VinylDNS API endpoints such as /zones and /zones/${zone_id}/recordsets
+// Same as ListFilter except for resources where StartFrom is an int instead of string
+type ListFilterInt struct {
+	NameFilter string
+	StartFrom  int
+	MaxItems   int
+}
+
 // NameSort specifies the name sort order for record sets returned by the global list record set response.
 // Valid values are ASC (ascending; default) and DESC (descending).
 type NameSort string

--- a/vinyldns/test-fixtures/recordsets/recordset-changes-list-1.json
+++ b/vinyldns/test-fixtures/recordsets/recordset-changes-list-1.json
@@ -1,7 +1,7 @@
 {
   "zoneId": "123",
-  "startFrom": "1",
-  "nextId": "2",
+  "startFrom": 1,
+  "nextId": 2,
   "maxItems": 1,
   "recordSetChanges": [{
     "status": "Complete",

--- a/vinyldns/test-fixtures/recordsets/recordset-changes-list-2.json
+++ b/vinyldns/test-fixtures/recordsets/recordset-changes-list-2.json
@@ -1,6 +1,6 @@
 {
   "zoneId": "123",
-  "startFrom": "2",
+  "startFrom": 2,
   "maxItems": 1,
   "recordSetChanges": [{
     "status": "Complete",

--- a/vinyldns/zones_test.go
+++ b/vinyldns/zones_test.go
@@ -88,7 +88,7 @@ func TestZonesListAll(t *testing.T) {
 			body:     zonesListJSON1,
 		},
 		{
-			endpoint: "http://host.com/zones?startFrom=2&maxItems=1",
+			endpoint: "http://host.com/zones?maxItems=1&startFrom=2",
 			code:     200,
 			body:     zonesListJSON2,
 		},
@@ -656,7 +656,7 @@ func TestZoneChangesListAll(t *testing.T) {
 			body:     zoneChangesListJSON1,
 		},
 		{
-			endpoint: "http://host.com/zones/123/changes?startFrom=2&maxItems=1",
+			endpoint: "http://host.com/zones/123/changes?maxItems=1&startFrom=2",
 			code:     200,
 			body:     zoneChangesListJSON2,
 		},


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.

### Description of the Change

I plan to submit a PR to terraform-provider-vinyldns in the near future to add some features, but before adding any functionality, I wanted to get this repo & terraform-provider-vinyldns in good shape. This PR should not be changing any functionality, just updating several things as described here:
- Updating to use go 1.21 from 1.17 which was EOL'd in Aug 2022
- Replacing deprecated go-aws-auth package with the official AWS SDK for AWS SigV4 signing of requests
- Replacing deprecated ioutil package with io/os as appropriate
- Updated Makefile to use latest version of VinylDNS for integration testing
- Following changes to support version 0.20.0 of VinylDNS
  - Updated Makefile to properly start/stop test containers
  - Updating RecordSetChanges calls to set startfrom & nextID to be integers instead of strings
  - Minor changes to tests to reflect current state of VinylDNS

Note: I'm not sure if I should be bumping the version of this package as part of this PR?

I will also be submitting a similar PR to terraform-provider-vinyldns in the very near future with similar updates.

### Why Should This Be In The Package?

To ensure this package doesn't get further out of date.

### Benefits

Support of current VinylDNS and using stable version of Go.

### Possible Drawbacks

None to my knowledge.

### Verification Process

Ran `make all` which does go test and then spins up docker container with VinylDNS 0.20.0 and does integration testing.

```
~ make all
test -z ""
go vet ./...
GO111MODULE=on go test ./... -cover
ok      github.com/vinyldns/go-vinyldns/vinyldns        0.375s  coverage: 84.6% of statements
GO111MODULE=on go build -ldflags "-X main.version=0.9.16" ./...
/Users/bdewald/go/1.21.9/src/github.com/vinyldns/vinyldns-0.20.0/quickstart/quickstart-vinyldns.sh \
                --clean
Killing running containers...
76382067785c
ea00febbe124
Removing containers...
76382067785c
ea00febbe124
Deleted Networks:
vinyldns_net

Clean up completed!
if [ ! -d "/Users/bdewald/go/1.21.9/src/github.com/vinyldns/vinyldns-0.20.0" ]; then \
                echo "github.com/vinyldns/vinyldns-0.20.0 not found in your GOPATH (necessary for acceptance tests), getting..."; \
                git clone \
                        --branch v0.20.0 \
                        https://github.com/vinyldns/vinyldns \
                        /Users/bdewald/go/1.21.9/src/github.com/vinyldns/vinyldns-0.20.0; \
        fi
/Users/bdewald/go/1.21.9/src/github.com/vinyldns/vinyldns-0.20.0/quickstart/quickstart-vinyldns.sh \
                --api \
                --version-tag 0.20.0
Starting VinylDNS (latest) the background...
[+] Running 2/0
[+] Running 2/5ldns_net                                                                                                                                       Created0.1s 
[+] Running 3/5ldns_net                                                                                                                                       Created0.2s 
[+] Running 4/5ldns_net                                                                                                                                       Created0.3s 
 ⠸ Network vinyldns_net                                                                                                                                       Created0.4s 
 ✔ Container vinyldns-api-integration                                                                                                                         Started0.2s 
 ! integration The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested        0.0s 
 ✔ Container vinyldns-api                                                                                                                                     Started0.3s 
 ! api The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                0.0s 

Waiting for VinylDNS API at http://localhost:9000 ................OK

VinylDNS API started! You can connect to the API via http://localhost:9000
To clean up the running containers:
    /Users/bdewald/go/1.21.9/src/github.com/vinyldns/vinyldns-0.20.0/quickstart/quickstart-vinyldns.sh --clean
GO111MODULE=on go test ./... -tags=integration
ok      github.com/vinyldns/go-vinyldns/vinyldns        43.921s
cat vinyldns/version.go | grep 'var Version = "0.9.16"'
var Version = "0.9.16"
GO111MODULE=on go install ./...
```

### Applicable Issues (Optional)

N/A
