### PR TITLE
Add record history api

### DIFF
--- a/vinyldns/endpoints.go
+++ b/vinyldns/endpoints.go
@@ -72,6 +72,13 @@ func recordSetChangesEP(c *Client, zoneID string, f ListFilter) string {
 	return concatStrs("", zoneEP(c, zoneID), "/recordsetchanges", query)
 }
 
+func recordSetChangeHistoryListEP(c *Client, f ListRecordHistoryFilter) string {
+	query := buildRecordHistoryQuery(f)
+	base := concatStrs("", c.Host, "/recordsetchange/history")
+
+	return concatStrs("", base, query)
+}
+
 func recordSetChangeEP(c *Client, zoneID, recordSetID, changeID string) string {
 	return concatStrs("", recordSetEP(c, zoneID, recordSetID), "/changes/", changeID)
 }
@@ -120,6 +127,37 @@ func buildQuery(f ListFilter, nameFilterName string) string {
 
 	if f.StartFrom != "" {
 		params = append(params, fmt.Sprintf("startFrom=%s", f.StartFrom))
+	}
+
+	if f.MaxItems != 0 {
+		params = append(params, fmt.Sprintf("maxItems=%d", f.MaxItems))
+	}
+
+	if len(params) == 0 {
+		query = ""
+	}
+
+	return query + strings.Join(params, "&")
+}
+
+func buildRecordHistoryQuery(f ListRecordHistoryFilter) string {
+	params := []string{}
+	query := "?"
+
+	if f.ZoneId != "" {
+		params = append(params, fmt.Sprintf("%s=%s", "zoneId", f.ZoneId))
+	}
+
+	if f.Fqdn != "" {
+		params = append(params, fmt.Sprintf("%s=%s", "fqdn", f.Fqdn))
+	}
+
+	if f.RecordType != "" {
+		params = append(params, fmt.Sprintf("%s=%s", "recordType", f.RecordType))
+	}
+
+	if f.StartFrom != 0 {
+		params = append(params, fmt.Sprintf("startFrom=%d", f.StartFrom))
 	}
 
 	if f.MaxItems != 0 {

--- a/vinyldns/endpoints_test.go
+++ b/vinyldns/endpoints_test.go
@@ -251,6 +251,38 @@ func TestRecordSetChangesEPWithQuery(t *testing.T) {
 	}
 }
 
+func TestRecordSetChangeHistoryEP(t *testing.T) {
+	rsc := recordSetChangeHistoryListEP(c, ListRecordHistoryFilter{
+		ZoneId:     "123",
+		Fqdn:       "ok.",
+		RecordType: "A",
+	})
+	expected := "http://host.com/recordsetchange/history?zoneId=123&fqdn=ok.&recordType=A"
+
+	if rsc != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", rsc)
+		t.Error("recordSetChangesEP should return the right endpoint")
+	}
+}
+
+func TestRecordSetChangeHistoryEPWithStartMaxQuery(t *testing.T) {
+	rsc := recordSetChangeHistoryListEP(c, ListRecordHistoryFilter{
+		ZoneId:     "123",
+		Fqdn:       "ok.",
+		RecordType: "A",
+		MaxItems:   3,
+		StartFrom:  1,
+	})
+	expected := "http://host.com/recordsetchange/history?zoneId=123&fqdn=ok.&recordType=A&startFrom=1&maxItems=3"
+
+	if rsc != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", rsc)
+		t.Error("recordSetChangesEP should return the right endpoint")
+	}
+}
+
 func TestRecordSetChangeEP(t *testing.T) {
 	rsc := recordSetChangeEP(c, "123", "456", "789")
 	expected := "http://host.com/zones/123/recordsets/456/changes/789"

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -219,6 +219,17 @@ func (c *Client) RecordSetChanges(zoneID string, f ListFilter) (*RecordSetChange
 	return rsc, nil
 }
 
+// RecordSetChangeHistory retrieves the RecordSetChangeHistory response for that particular record using the ListRecordHistoryFilter passed.
+func (c *Client) RecordSetChangeHistory(f ListRecordHistoryFilter) (*RecordSetChangeHistory, error) {
+	rsc := &RecordSetChangeHistory{}
+	err := resourceRequest(c, recordSetChangeHistoryListEP(c, f), "GET", nil, rsc)
+	if err != nil {
+		return &RecordSetChangeHistory{}, err
+	}
+
+	return rsc, nil
+}
+
 // RecordSetChangesListAll retrieves the complete list of record set changes for the Zone ListFilter criteria passed.
 // Handles paging through results on the user's behalf.
 func (c *Client) RecordSetChangesListAll(zoneID string, filter ListFilter) ([]RecordSetChange, error) {

--- a/vinyldns/recordsets_resources.go
+++ b/vinyldns/recordsets_resources.go
@@ -34,6 +34,15 @@ type RecordSetChanges struct {
 	Status           string            `json:"status,omitempty"`
 }
 
+// RecordSetChanges represents a recordset changes response
+type RecordSetChangeHistory struct {
+	RecordSetChanges []RecordSetChange `json:"recordSetChanges"`
+	ZoneID           string            `json:"zoneId,omitempty"`
+	StartFrom        int               `json:"startFrom,omitempty"`
+	NextID           int               `json:"nextId,omitempty"`
+	MaxItems         int               `json:"maxItems,omitempty"`
+}
+
 // RecordSet represents a DNS record set.
 type RecordSet struct {
 	ID           string   `json:"id,omitempty"`

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -50,6 +50,16 @@ type ListFilter struct {
 	MaxItems   int
 }
 
+// ListRecordHistoryFilter represents the list query parameters that may be passed to
+// VinylDNS API endpoint: recordsetchange/history
+type ListRecordHistoryFilter struct {
+	ZoneId     string
+	StartFrom  int
+	MaxItems   int
+	Fqdn       string
+	RecordType string
+}
+
 // NameSort specifies the name sort order for record sets returned by the global list record set response.
 // Valid values are ASC (ascending; default) and DESC (descending).
 type NameSort string


### PR DESCRIPTION
Adding the recordset history api which has recently been included to VinylDNS.
