### PR TITLE
Add missing VinylDNS API endpoints

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Comcast Cable Communications Management, LLC
+   Copyright 2026 Comcast Cable Communications Management, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 go-vinyldns
 
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 go-vinyldns
 
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vinyldns/batch_changes.go
+++ b/vinyldns/batch_changes.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -47,6 +47,63 @@ func (c *Client) BatchRecordChangeCreate(change *BatchRecordChange) (*BatchRecor
 	err = resourceRequest(c, batchRecordChangesEP(c), "POST", cJSON, resource)
 	if err != nil {
 		return &BatchRecordChangeUpdateResponse{}, err
+	}
+
+	return resource, nil
+}
+
+// BatchRecordChangeApprove approves a batch record change in manual review.
+func (c *Client) BatchRecordChangeApprove(changeID string, review *BatchChangeReview) (*BatchRecordChange, error) {
+	var reviewJSON []byte
+	var err error
+	if review != nil {
+		reviewJSON, err = json.Marshal(review)
+		if err != nil {
+			return nil, err
+		}
+	}
+	resource := &BatchRecordChange{}
+	err = resourceRequest(c, batchRecordChangeApproveEP(c, changeID), "POST", reviewJSON, resource)
+	if err != nil {
+		return &BatchRecordChange{}, err
+	}
+
+	return resource, nil
+}
+
+// BatchRecordChangeReject rejects a batch record change in manual review.
+func (c *Client) BatchRecordChangeReject(changeID string, review *BatchChangeReview) (*BatchRecordChange, error) {
+	var reviewJSON []byte
+	var err error
+	if review != nil {
+		reviewJSON, err = json.Marshal(review)
+		if err != nil {
+			return nil, err
+		}
+	}
+	resource := &BatchRecordChange{}
+	err = resourceRequest(c, batchRecordChangeRejectEP(c, changeID), "POST", reviewJSON, resource)
+	if err != nil {
+		return &BatchRecordChange{}, err
+	}
+
+	return resource, nil
+}
+
+// BatchRecordChangeCancel cancels a batch record change.
+func (c *Client) BatchRecordChangeCancel(changeID string, review *BatchChangeReview) (*BatchRecordChange, error) {
+	var reviewJSON []byte
+	var err error
+	if review != nil {
+		reviewJSON, err = json.Marshal(review)
+		if err != nil {
+			return nil, err
+		}
+	}
+	resource := &BatchRecordChange{}
+	err = resourceRequest(c, batchRecordChangeCancelEP(c, changeID), "POST", reviewJSON, resource)
+	if err != nil {
+		return &BatchRecordChange{}, err
 	}
 
 	return resource, nil

--- a/vinyldns/batch_changes.go
+++ b/vinyldns/batch_changes.go
@@ -54,44 +54,20 @@ func (c *Client) BatchRecordChangeCreate(change *BatchRecordChange) (*BatchRecor
 
 // BatchRecordChangeApprove approves a batch record change in manual review.
 func (c *Client) BatchRecordChangeApprove(changeID string, review *BatchChangeReview) (*BatchRecordChange, error) {
-	var reviewJSON []byte
-	var err error
-	if review != nil {
-		reviewJSON, err = json.Marshal(review)
-		if err != nil {
-			return nil, err
-		}
-	}
-	resource := &BatchRecordChange{}
-	err = resourceRequest(c, batchRecordChangeApproveEP(c, changeID), "POST", reviewJSON, resource)
-	if err != nil {
-		return &BatchRecordChange{}, err
-	}
-
-	return resource, nil
+	return c.batchRecordChangeReviewAction(changeID, review, batchRecordChangeApproveEP)
 }
 
 // BatchRecordChangeReject rejects a batch record change in manual review.
 func (c *Client) BatchRecordChangeReject(changeID string, review *BatchChangeReview) (*BatchRecordChange, error) {
-	var reviewJSON []byte
-	var err error
-	if review != nil {
-		reviewJSON, err = json.Marshal(review)
-		if err != nil {
-			return nil, err
-		}
-	}
-	resource := &BatchRecordChange{}
-	err = resourceRequest(c, batchRecordChangeRejectEP(c, changeID), "POST", reviewJSON, resource)
-	if err != nil {
-		return &BatchRecordChange{}, err
-	}
-
-	return resource, nil
+	return c.batchRecordChangeReviewAction(changeID, review, batchRecordChangeRejectEP)
 }
 
 // BatchRecordChangeCancel cancels a batch record change.
 func (c *Client) BatchRecordChangeCancel(changeID string, review *BatchChangeReview) (*BatchRecordChange, error) {
+	return c.batchRecordChangeReviewAction(changeID, review, batchRecordChangeCancelEP)
+}
+
+func (c *Client) batchRecordChangeReviewAction(changeID string, review *BatchChangeReview, endpoint func(*Client, string) string) (*BatchRecordChange, error) {
 	var reviewJSON []byte
 	var err error
 	if review != nil {
@@ -101,7 +77,7 @@ func (c *Client) BatchRecordChangeCancel(changeID string, review *BatchChangeRev
 		}
 	}
 	resource := &BatchRecordChange{}
-	err = resourceRequest(c, batchRecordChangeCancelEP(c, changeID), "POST", reviewJSON, resource)
+	err = resourceRequest(c, endpoint(c, changeID), "POST", reviewJSON, resource)
 	if err != nil {
 		return &BatchRecordChange{}, err
 	}

--- a/vinyldns/batch_changes.go
+++ b/vinyldns/batch_changes.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/batch_changes_resources.go
+++ b/vinyldns/batch_changes_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -81,4 +81,9 @@ type BatchRecordChange struct {
 	ReviewTimestamp    string         `json:"reviewTimestamp,omitempty"`
 	ScheduledTime      string         `json:"scheduledTime,omitempty"`
 	CancelledTimestamp string         `json:"cancelledTimestamp,omitempty"`
+}
+
+// BatchChangeReview represents approve/reject/cancel review payloads.
+type BatchChangeReview struct {
+	ReviewComment string `json:"reviewComment,omitempty"`
 }

--- a/vinyldns/batch_changes_resources.go
+++ b/vinyldns/batch_changes_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/batch_changes_review_test.go
+++ b/vinyldns/batch_changes_review_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import "testing"
+
+func TestBatchRecordChangeApprove(t *testing.T) {
+	changeJSON, err := readFile("test-fixtures/batch-changes/batch-change.json")
+	if err != nil {
+		t.Error(err)
+	}
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/zones/batchrecordchanges/123/approve",
+			code:     202,
+			body:     changeJSON,
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.BatchRecordChangeApprove("123", &BatchChangeReview{ReviewComment: "ok"})
+	if err != nil {
+		t.Error(err)
+	}
+	if resp.ID == "" {
+		t.Error("Expected batch change ID to have a value")
+	}
+}
+
+func TestBatchRecordChangeReject(t *testing.T) {
+	changeJSON, err := readFile("test-fixtures/batch-changes/batch-change.json")
+	if err != nil {
+		t.Error(err)
+	}
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/zones/batchrecordchanges/123/reject",
+			code:     200,
+			body:     changeJSON,
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.BatchRecordChangeReject("123", &BatchChangeReview{ReviewComment: "nope"})
+	if err != nil {
+		t.Error(err)
+	}
+	if resp.ID == "" {
+		t.Error("Expected batch change ID to have a value")
+	}
+}
+
+func TestBatchRecordChangeCancel(t *testing.T) {
+	changeJSON, err := readFile("test-fixtures/batch-changes/batch-change.json")
+	if err != nil {
+		t.Error(err)
+	}
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/zones/batchrecordchanges/123/cancel",
+			code:     200,
+			body:     changeJSON,
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.BatchRecordChangeCancel("123", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if resp.ID == "" {
+		t.Error("Expected batch change ID to have a value")
+	}
+}

--- a/vinyldns/batch_changes_review_test.go
+++ b/vinyldns/batch_changes_review_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/batch_changes_test.go
+++ b/vinyldns/batch_changes_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/batch_changes_test.go
+++ b/vinyldns/batch_changes_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/client.go
+++ b/vinyldns/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/client.go
+++ b/vinyldns/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/client_test.go
+++ b/vinyldns/client_test.go
@@ -14,14 +14,14 @@ package vinyldns
 
 import (
 	"fmt"
-	"os"
 	"testing"
 )
 
 func TestNewClientFromEnv(t *testing.T) {
-	os.Setenv("VINYLDNS_ACCESS_KEY", "accessKey")
-	os.Setenv("VINYLDNS_SECRET_KEY", "secretKey")
-	os.Setenv("VINYLDNS_HOST", "https://vinyldns-api.com")
+	t.Setenv("VINYLDNS_ACCESS_KEY", "accessKey")
+	t.Setenv("VINYLDNS_SECRET_KEY", "secretKey")
+	t.Setenv("VINYLDNS_HOST", "https://vinyldns-api.com")
+	t.Setenv("VINYLDNS_USER_AGENT", "")
 
 	client := NewClientFromEnv()
 
@@ -38,13 +38,10 @@ func TestNewClientFromEnv(t *testing.T) {
 		t.Error("NewClientFromEnv should set a default UserAgent if one is not present in the environment")
 	}
 
-	os.Setenv("VINYLDNS_ACCESS_KEY", "")
-	os.Setenv("VINYLDNS_SECRET_KEY", "")
-	os.Setenv("VINYLDNS_HOST", "")
 }
 
 func TestNewClientFromEnvWithUserAgent(t *testing.T) {
-	os.Setenv("VINYLDNS_USER_AGENT", "foo")
+	t.Setenv("VINYLDNS_USER_AGENT", "foo")
 
 	client := NewClientFromEnv()
 
@@ -52,5 +49,4 @@ func TestNewClientFromEnvWithUserAgent(t *testing.T) {
 		t.Error("NewClientFromEnv should set a UserAgent from the environment if one is present")
 	}
 
-	os.Setenv("VINYLDNS_USER_AGENT", "")
 }

--- a/vinyldns/client_test.go
+++ b/vinyldns/client_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/client_test.go
+++ b/vinyldns/client_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/config_test.go
+++ b/vinyldns/config_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestNewConfigFromEnv(t *testing.T) {
+	t.Setenv("VINYLDNS_USER_AGENT", "")
+
 	accessKey := envOrDefault("VINYLDNS_ACCESS_KEY", "accesskey123")
 	secretKey := envOrDefault("VINYLDNS_SECRET_KEY", "secretkey123")
 	host := envOrDefault("VINYLDNS_HOST", "host.name.com")
@@ -32,7 +34,7 @@ func TestNewConfigFromEnv(t *testing.T) {
 }
 
 func TestNewConfigFromEnvWithExplicitUserAgent(t *testing.T) {
-	os.Setenv("VINYLDNS_USER_AGENT", "some customer UA")
+	t.Setenv("VINYLDNS_USER_AGENT", "some customer UA")
 
 	defaultConfig := NewConfigFromEnv()
 

--- a/vinyldns/config_test.go
+++ b/vinyldns/config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/config_test.go
+++ b/vinyldns/config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/endpoints.go
+++ b/vinyldns/endpoints.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -21,6 +21,32 @@ func zonesEP(c *Client) string {
 	return concatStrs("", c.Host, "/zones")
 }
 
+func pingEP(c *Client) string {
+	return concatStrs("", c.Host, "/ping")
+}
+
+func healthEP(c *Client) string {
+	return concatStrs("", c.Host, "/health")
+}
+
+func colorEP(c *Client) string {
+	return concatStrs("", c.Host, "/color")
+}
+
+func prometheusMetricsEP(c *Client, names []string) string {
+	base := concatStrs("", c.Host, "/metrics/prometheus")
+	query := buildPrometheusQuery(names)
+	return concatStrs("", base, query)
+}
+
+func statusEP(c *Client) string {
+	return concatStrs("", c.Host, "/status")
+}
+
+func statusUpdateEP(c *Client, processingDisabled bool) string {
+	return concatStrs("", statusEP(c), fmt.Sprintf("?processingDisabled=%t", processingDisabled))
+}
+
 func zonesListEP(c *Client, f ListFilter) string {
 	query := buildQuery(f, "nameFilter")
 
@@ -35,6 +61,10 @@ func zoneDetailsEP(c *Client, id string) string {
 	return concatStrs("", zonesEP(c), "/", id, "/details")
 }
 
+func zoneBackendIDsEP(c *Client) string {
+	return concatStrs("", zonesEP(c), "/backendids")
+}
+
 func zoneNameEP(c *Client, name string) string {
 	return concatStrs("", zonesEP(c), "/name/", name)
 }
@@ -43,6 +73,15 @@ func zoneChangesEP(c *Client, id string, f ListFilter) string {
 	query := buildQuery(f, "nameFilter")
 
 	return concatStrs("", zoneEP(c, id), "/changes", query)
+}
+
+func zoneDeletedChangesEP(c *Client, f DeletedZonesFilter) string {
+	query := buildDeletedZonesQuery(f)
+	return concatStrs("", zonesEP(c), "/deleted/changes", query)
+}
+
+func zoneACLRulesEP(c *Client, id string) string {
+	return concatStrs("", zoneEP(c, id), "/acl/rules")
 }
 
 func zoneSyncEP(c *Client, id string) string {
@@ -70,6 +109,10 @@ func recordSetEP(c *Client, zoneID, recordSetID string) string {
 	return concatStrs("", recordSetsEP(c, zoneID), "/", recordSetID)
 }
 
+func recordSetCountEP(c *Client, zoneID string) string {
+	return concatStrs("", zoneEP(c, zoneID), "/recordsetcount")
+}
+
 func recordSetChangesEP(c *Client, zoneID string, f ListFilterRecordSetChanges) string {
 	query := buildRecordSetChangesQuery(f)
 
@@ -78,6 +121,11 @@ func recordSetChangesEP(c *Client, zoneID string, f ListFilterRecordSetChanges) 
 
 func recordSetChangeEP(c *Client, zoneID, recordSetID, changeID string) string {
 	return concatStrs("", recordSetEP(c, zoneID, recordSetID), "/changes/", changeID)
+}
+
+func recordSetChangeHistoryEP(c *Client, f RecordSetChangeHistoryFilter) string {
+	query := buildRecordSetChangeHistoryQuery(f)
+	return concatStrs("", c.Host, "/recordsetchange/history", query)
 }
 
 func groupsEP(c *Client) string {
@@ -106,12 +154,58 @@ func groupActivityEP(c *Client, groupID string) string {
 	return concatStrs("", groupEP(c, groupID), "/activity")
 }
 
+func groupChangeEP(c *Client, groupChangeID string) string {
+	return concatStrs("", groupsEP(c), "/change/", groupChangeID)
+}
+
+func groupValidDomainsEP(c *Client) string {
+	return concatStrs("", groupsEP(c), "/valid/domains")
+}
+
+func usersEP(c *Client) string {
+	return concatStrs("", c.Host, "/users")
+}
+
+func userEP(c *Client, userIdentifier string) string {
+	return concatStrs("", usersEP(c), "/", userIdentifier)
+}
+
+func userLockEP(c *Client, userID string) string {
+	return concatStrs("", userEP(c, userID), "/lock")
+}
+
+func userUnlockEP(c *Client, userID string) string {
+	return concatStrs("", userEP(c, userID), "/unlock")
+}
+
 func batchRecordChangesEP(c *Client) string {
 	return concatStrs("", zonesEP(c), "/batchrecordchanges")
 }
 
 func batchRecordChangeEP(c *Client, changeID string) string {
 	return concatStrs("", batchRecordChangesEP(c), "/", changeID)
+}
+
+func batchRecordChangeApproveEP(c *Client, changeID string) string {
+	return concatStrs("", batchRecordChangeEP(c, changeID), "/approve")
+}
+
+func batchRecordChangeRejectEP(c *Client, changeID string) string {
+	return concatStrs("", batchRecordChangeEP(c, changeID), "/reject")
+}
+
+func batchRecordChangeCancelEP(c *Client, changeID string) string {
+	return concatStrs("", batchRecordChangeEP(c, changeID), "/cancel")
+}
+
+func zoneChangesFailureEP(c *Client, f ListFilter) string {
+	query := buildStartMaxQuery(f)
+	return concatStrs("", c.Host, "/metrics/health/zonechangesfailure", query)
+}
+
+func recordSetChangesFailureEP(c *Client, zoneID string, f ListFilter) string {
+	query := buildStartMaxQuery(f)
+	return concatStrs("", c.Host, "/metrics/health/zones/", zoneID, "/recordsetchangesfailure", query)
 }
 
 func buildQuery(f ListFilter, nameFilterName string) string {
@@ -137,6 +231,52 @@ func buildQuery(f ListFilter, nameFilterName string) string {
 	return query + strings.Join(params, "&")
 }
 
+func buildStartMaxQuery(f ListFilter) string {
+	params := []string{}
+	query := "?"
+
+	if f.StartFrom != "" {
+		params = append(params, fmt.Sprintf("startFrom=%s", f.StartFrom))
+	}
+
+	if f.MaxItems != 0 {
+		params = append(params, fmt.Sprintf("maxItems=%d", f.MaxItems))
+	}
+
+	if len(params) == 0 {
+		query = ""
+	}
+
+	return query + strings.Join(params, "&")
+}
+
+func buildDeletedZonesQuery(f DeletedZonesFilter) string {
+	params := []string{}
+	query := "?"
+
+	if f.NameFilter != "" {
+		params = append(params, fmt.Sprintf("nameFilter=%s", f.NameFilter))
+	}
+
+	if f.StartFrom != "" {
+		params = append(params, fmt.Sprintf("startFrom=%s", f.StartFrom))
+	}
+
+	if f.MaxItems != 0 {
+		params = append(params, fmt.Sprintf("maxItems=%d", f.MaxItems))
+	}
+
+	if f.IgnoreAccess != nil {
+		params = append(params, fmt.Sprintf("ignoreAccess=%t", *f.IgnoreAccess))
+	}
+
+	if len(params) == 0 {
+		query = ""
+	}
+
+	return query + strings.Join(params, "&")
+}
+
 func buildRecordSetChangesQuery(f ListFilterRecordSetChanges) string {
 	params := []string{}
 	query := "?"
@@ -147,6 +287,42 @@ func buildRecordSetChangesQuery(f ListFilterRecordSetChanges) string {
 
 	if f.MaxItems != 0 {
 		params = append(params, fmt.Sprintf("maxItems=%d", f.MaxItems))
+	}
+
+	if len(params) == 0 {
+		query = ""
+	}
+
+	return query + strings.Join(params, "&")
+}
+
+func buildRecordSetChangeHistoryQuery(f RecordSetChangeHistoryFilter) string {
+	params := []string{}
+	query := "?"
+
+	params = append(params, fmt.Sprintf("zoneId=%s", f.ZoneID))
+	params = append(params, fmt.Sprintf("fqdn=%s", f.FQDN))
+	params = append(params, fmt.Sprintf("recordType=%s", f.RecordType))
+
+	if f.StartFrom != "" {
+		params = append(params, fmt.Sprintf("startFrom=%s", f.StartFrom))
+	}
+
+	if f.MaxItems != 0 {
+		params = append(params, fmt.Sprintf("maxItems=%d", f.MaxItems))
+	}
+
+	return query + strings.Join(params, "&")
+}
+
+func buildPrometheusQuery(names []string) string {
+	params := []string{}
+	query := "?"
+
+	for _, name := range names {
+		if name != "" {
+			params = append(params, fmt.Sprintf("name=%s", name))
+		}
 	}
 
 	if len(params) == 0 {

--- a/vinyldns/endpoints.go
+++ b/vinyldns/endpoints.go
@@ -300,9 +300,15 @@ func buildRecordSetChangeHistoryQuery(f RecordSetChangeHistoryFilter) string {
 	params := []string{}
 	query := "?"
 
-	params = append(params, fmt.Sprintf("zoneId=%s", f.ZoneID))
-	params = append(params, fmt.Sprintf("fqdn=%s", f.FQDN))
-	params = append(params, fmt.Sprintf("recordType=%s", f.RecordType))
+	if f.ZoneID != "" {
+		params = append(params, fmt.Sprintf("zoneId=%s", f.ZoneID))
+	}
+	if f.FQDN != "" {
+		params = append(params, fmt.Sprintf("fqdn=%s", f.FQDN))
+	}
+	if f.RecordType != "" {
+		params = append(params, fmt.Sprintf("recordType=%s", f.RecordType))
+	}
 
 	if f.StartFrom != "" {
 		params = append(params, fmt.Sprintf("startFrom=%s", f.StartFrom))
@@ -310,6 +316,10 @@ func buildRecordSetChangeHistoryQuery(f RecordSetChangeHistoryFilter) string {
 
 	if f.MaxItems != 0 {
 		params = append(params, fmt.Sprintf("maxItems=%d", f.MaxItems))
+	}
+
+	if len(params) == 0 {
+		query = ""
 	}
 
 	return query + strings.Join(params, "&")

--- a/vinyldns/endpoints.go
+++ b/vinyldns/endpoints.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/endpoints_test.go
+++ b/vinyldns/endpoints_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -388,6 +388,206 @@ func TestBatchRecordChangeEP(t *testing.T) {
 	}
 }
 
+func TestHealthEndpoints(t *testing.T) {
+	ping := pingEP(c)
+	expected := "http://host.com/ping"
+	if ping != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", ping)
+		t.Error("pingEP should return the right endpoint")
+	}
+
+	health := healthEP(c)
+	expected = "http://host.com/health"
+	if health != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", health)
+		t.Error("healthEP should return the right endpoint")
+	}
+
+	color := colorEP(c)
+	expected = "http://host.com/color"
+	if color != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", color)
+		t.Error("colorEP should return the right endpoint")
+	}
+
+	metrics := prometheusMetricsEP(c, []string{"foo", "bar"})
+	expected = "http://host.com/metrics/prometheus?name=foo&name=bar"
+	if metrics != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", metrics)
+		t.Error("prometheusMetricsEP should return the right endpoint")
+	}
+
+	status := statusEP(c)
+	expected = "http://host.com/status"
+	if status != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", status)
+		t.Error("statusEP should return the right endpoint")
+	}
+
+	update := statusUpdateEP(c, true)
+	expected = "http://host.com/status?processingDisabled=true"
+	if update != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", update)
+		t.Error("statusUpdateEP should return the right endpoint")
+	}
+}
+
+func TestZoneExtrasEP(t *testing.T) {
+	backendIDs := zoneBackendIDsEP(c)
+	expected := "http://host.com/zones/backendids"
+	if backendIDs != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", backendIDs)
+		t.Error("zoneBackendIDsEP should return the right endpoint")
+	}
+
+	ignoreAccess := true
+	deleted := zoneDeletedChangesEP(c, DeletedZonesFilter{
+		NameFilter:   "foo*",
+		StartFrom:    "next",
+		MaxItems:     5,
+		IgnoreAccess: &ignoreAccess,
+	})
+	expected = "http://host.com/zones/deleted/changes?nameFilter=foo*&startFrom=next&maxItems=5&ignoreAccess=true"
+	if deleted != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", deleted)
+		t.Error("zoneDeletedChangesEP should return the right endpoint")
+	}
+
+	aclRules := zoneACLRulesEP(c, "123")
+	expected = "http://host.com/zones/123/acl/rules"
+	if aclRules != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", aclRules)
+		t.Error("zoneACLRulesEP should return the right endpoint")
+	}
+}
+
+func TestRecordSetExtrasEP(t *testing.T) {
+	count := recordSetCountEP(c, "123")
+	expected := "http://host.com/zones/123/recordsetcount"
+	if count != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", count)
+		t.Error("recordSetCountEP should return the right endpoint")
+	}
+
+	history := recordSetChangeHistoryEP(c, RecordSetChangeHistoryFilter{
+		ZoneID:     "z1",
+		FQDN:       "ok.",
+		RecordType: "A",
+		StartFrom:  "1",
+		MaxItems:   2,
+	})
+	expected = "http://host.com/recordsetchange/history?zoneId=z1&fqdn=ok.&recordType=A&startFrom=1&maxItems=2"
+	if history != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", history)
+		t.Error("recordSetChangeHistoryEP should return the right endpoint")
+	}
+
+	failures := recordSetChangesFailureEP(c, "z2", ListFilter{
+		StartFrom: "2",
+		MaxItems:  3,
+	})
+	expected = "http://host.com/metrics/health/zones/z2/recordsetchangesfailure?startFrom=2&maxItems=3"
+	if failures != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", failures)
+		t.Error("recordSetChangesFailureEP should return the right endpoint")
+	}
+}
+
+func TestGroupExtrasEP(t *testing.T) {
+	change := groupChangeEP(c, "123")
+	expected := "http://host.com/groups/change/123"
+	if change != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", change)
+		t.Error("groupChangeEP should return the right endpoint")
+	}
+
+	domains := groupValidDomainsEP(c)
+	expected = "http://host.com/groups/valid/domains"
+	if domains != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", domains)
+		t.Error("groupValidDomainsEP should return the right endpoint")
+	}
+}
+
+func TestUserExtrasEP(t *testing.T) {
+	user := userEP(c, "ok")
+	expected := "http://host.com/users/ok"
+	if user != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", user)
+		t.Error("userEP should return the right endpoint")
+	}
+
+	lock := userLockEP(c, "ok")
+	expected = "http://host.com/users/ok/lock"
+	if lock != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", lock)
+		t.Error("userLockEP should return the right endpoint")
+	}
+
+	unlock := userUnlockEP(c, "ok")
+	expected = "http://host.com/users/ok/unlock"
+	if unlock != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", unlock)
+		t.Error("userUnlockEP should return the right endpoint")
+	}
+}
+
+func TestBatchReviewEP(t *testing.T) {
+	approve := batchRecordChangeApproveEP(c, "123")
+	expected := "http://host.com/zones/batchrecordchanges/123/approve"
+	if approve != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", approve)
+		t.Error("batchRecordChangeApproveEP should return the right endpoint")
+	}
+
+	reject := batchRecordChangeRejectEP(c, "123")
+	expected = "http://host.com/zones/batchrecordchanges/123/reject"
+	if reject != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", reject)
+		t.Error("batchRecordChangeRejectEP should return the right endpoint")
+	}
+
+	cancel := batchRecordChangeCancelEP(c, "123")
+	expected = "http://host.com/zones/batchrecordchanges/123/cancel"
+	if cancel != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", cancel)
+		t.Error("batchRecordChangeCancelEP should return the right endpoint")
+	}
+}
+
+func TestZoneChangesFailureEP(t *testing.T) {
+	failures := zoneChangesFailureEP(c, ListFilter{
+		StartFrom: "2",
+		MaxItems:  3,
+	})
+	expected := "http://host.com/metrics/health/zonechangesfailure?startFrom=2&maxItems=3"
+	if failures != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", failures)
+		t.Error("zoneChangesFailureEP should return the right endpoint")
+	}
+}
+
 func TestBuildQuery(t *testing.T) {
 	query := buildQuery(ListFilter{
 		MaxItems:   1,
@@ -410,6 +610,65 @@ func TestBuildQueryWithNoQuery(t *testing.T) {
 		fmt.Printf("Expected: %s", expected)
 		fmt.Printf("Actual: %s", query)
 		t.Error("buildQuery should return the right string")
+	}
+}
+
+func TestBuildStartMaxQuery(t *testing.T) {
+	query := buildStartMaxQuery(ListFilter{
+		StartFrom: "2",
+		MaxItems:  3,
+	})
+	expected := "?startFrom=2&maxItems=3"
+
+	if query != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", query)
+		t.Error("buildStartMaxQuery should return the right string")
+	}
+}
+
+func TestBuildDeletedZonesQuery(t *testing.T) {
+	ignoreAccess := true
+	query := buildDeletedZonesQuery(DeletedZonesFilter{
+		NameFilter:   "foo*",
+		StartFrom:    "next",
+		MaxItems:     5,
+		IgnoreAccess: &ignoreAccess,
+	})
+	expected := "?nameFilter=foo*&startFrom=next&maxItems=5&ignoreAccess=true"
+
+	if query != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", query)
+		t.Error("buildDeletedZonesQuery should return the right string")
+	}
+}
+
+func TestBuildRecordSetChangeHistoryQuery(t *testing.T) {
+	query := buildRecordSetChangeHistoryQuery(RecordSetChangeHistoryFilter{
+		ZoneID:     "zone-1",
+		FQDN:       "ok.",
+		RecordType: "A",
+		StartFrom:  "1",
+		MaxItems:   2,
+	})
+	expected := "?zoneId=zone-1&fqdn=ok.&recordType=A&startFrom=1&maxItems=2"
+
+	if query != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", query)
+		t.Error("buildRecordSetChangeHistoryQuery should return the right string")
+	}
+}
+
+func TestBuildPrometheusQuery(t *testing.T) {
+	query := buildPrometheusQuery([]string{"one", "two"})
+	expected := "?name=one&name=two"
+
+	if query != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", query)
+		t.Error("buildPrometheusQuery should return the right string")
 	}
 }
 

--- a/vinyldns/endpoints_test.go
+++ b/vinyldns/endpoints_test.go
@@ -661,6 +661,21 @@ func TestBuildRecordSetChangeHistoryQuery(t *testing.T) {
 	}
 }
 
+func TestBuildRecordSetChangeHistoryQuerySkipsEmptyRequiredFields(t *testing.T) {
+	query := buildRecordSetChangeHistoryQuery(RecordSetChangeHistoryFilter{
+		ZoneID:    "zone-1",
+		MaxItems:  2,
+		StartFrom: "1",
+	})
+	expected := "?zoneId=zone-1&startFrom=1&maxItems=2"
+
+	if query != expected {
+		fmt.Printf("Expected: %s", expected)
+		fmt.Printf("Actual: %s", query)
+		t.Error("buildRecordSetChangeHistoryQuery should skip empty required fields")
+	}
+}
+
 func TestBuildPrometheusQuery(t *testing.T) {
 	query := buildPrometheusQuery([]string{"one", "two"})
 	expected := "?name=one&name=two"

--- a/vinyldns/endpoints_test.go
+++ b/vinyldns/endpoints_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/groups.go
+++ b/vinyldns/groups.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -138,4 +138,26 @@ func (c *Client) GroupActivity(groupID string) (*GroupChanges, error) {
 	}
 
 	return activity, nil
+}
+
+// GroupChange retrieves a group change by ID.
+func (c *Client) GroupChange(groupChangeID string) (*GroupChange, error) {
+	change := &GroupChange{}
+	err := resourceRequest(c, groupChangeEP(c, groupChangeID), "GET", nil, change)
+	if err != nil {
+		return nil, err
+	}
+
+	return change, nil
+}
+
+// GroupValidDomains retrieves valid email domains for groups.
+func (c *Client) GroupValidDomains() ([]string, error) {
+	var domains []string
+	err := resourceRequest(c, groupValidDomainsEP(c), "GET", nil, &domains)
+	if err != nil {
+		return nil, err
+	}
+
+	return domains, nil
 }

--- a/vinyldns/groups.go
+++ b/vinyldns/groups.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/groups_extra_test.go
+++ b/vinyldns/groups_extra_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import "testing"
+
+func TestGroupChange(t *testing.T) {
+	changeJSON := `{
+		"id": "c1",
+		"userId": "u1",
+		"userName": "testuser",
+		"changeType": "Update",
+		"created": "now",
+		"groupChangeMessage": "updated group",
+		"newGroup": {"id": "g1", "name": "test-group"},
+		"oldGroup": {"id": "g1", "name": "test-group"}
+	}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/groups/change/c1",
+			code:     200,
+			body:     changeJSON,
+		},
+	})
+	defer server.Close()
+
+	change, err := client.GroupChange("c1")
+	if err != nil {
+		t.Error(err)
+	}
+	if change.ID != "c1" {
+		t.Error("Expected group change ID to be c1")
+	}
+}
+
+func TestGroupValidDomains(t *testing.T) {
+	domainsJSON := `["gmail.com","test.com"]`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/groups/valid/domains",
+			code:     200,
+			body:     domainsJSON,
+		},
+	})
+	defer server.Close()
+
+	domains, err := client.GroupValidDomains()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(domains) != 2 {
+		t.Error("Expected valid domains length to be 2")
+	}
+}

--- a/vinyldns/groups_extra_test.go
+++ b/vinyldns/groups_extra_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/groups_helpers.go
+++ b/vinyldns/groups_helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/groups_resources.go
+++ b/vinyldns/groups_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -55,11 +55,14 @@ type GroupMembers struct {
 
 // GroupChange represents a group change event object.
 type GroupChange struct {
-	UserID     string `json:"userId,omitempty"`
-	Created    string `json:"created,omitempty"`
-	ChangeType string `json:"changeType,omitempty"`
-	NewGroup   Group  `json:"newGroup,omitempty"`
-	OldGroup   Group  `json:"oldGroup,omitempty"`
+	ID                 string `json:"id,omitempty"`
+	UserID             string `json:"userId,omitempty"`
+	UserName           string `json:"userName,omitempty"`
+	Created            string `json:"created,omitempty"`
+	ChangeType         string `json:"changeType,omitempty"`
+	GroupChangeMessage string `json:"groupChangeMessage,omitempty"`
+	NewGroup           Group  `json:"newGroup,omitempty"`
+	OldGroup           Group  `json:"oldGroup,omitempty"`
 }
 
 // GroupChanges is represents the group changes.

--- a/vinyldns/groups_resources.go
+++ b/vinyldns/groups_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/groups_test.go
+++ b/vinyldns/groups_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/groups_test.go
+++ b/vinyldns/groups_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/health.go
+++ b/vinyldns/health.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+// Ping performs a health check that returns "PONG".
+func (c *Client) Ping() (string, error) {
+	_, body, err := resourceRequestRaw(c, pingEP(c), "GET", nil)
+	if err != nil {
+		return "", err
+	}
+
+	return body, nil
+}
+
+// Health performs a comprehensive health check.
+func (c *Client) Health() error {
+	_, _, err := resourceRequestRaw(c, healthEP(c), "GET", nil)
+	return err
+}
+
+// Color returns the current blue/green deployment color.
+func (c *Client) Color() (string, error) {
+	_, body, err := resourceRequestRaw(c, colorEP(c), "GET", nil)
+	if err != nil {
+		return "", err
+	}
+
+	return body, nil
+}
+
+// MetricsPrometheus returns metrics in Prometheus text format.
+func (c *Client) MetricsPrometheus(names []string) (string, error) {
+	_, body, err := resourceRequestRaw(c, prometheusMetricsEP(c, names), "GET", nil)
+	if err != nil {
+		return "", err
+	}
+
+	return body, nil
+}

--- a/vinyldns/health.go
+++ b/vinyldns/health.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/health_test.go
+++ b/vinyldns/health_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import "testing"
+
+func TestPing(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/ping",
+			code:     200,
+			body:     "PONG",
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.Ping()
+	if err != nil {
+		t.Error(err)
+	}
+	if resp != "PONG" {
+		t.Error("Expected ping response to be PONG")
+	}
+}
+
+func TestHealth(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/health",
+			code:     200,
+			body:     "",
+		},
+	})
+	defer server.Close()
+
+	if err := client.Health(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestColor(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/color",
+			code:     200,
+			body:     "blue",
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.Color()
+	if err != nil {
+		t.Error(err)
+	}
+	if resp != "blue" {
+		t.Error("Expected color response to be blue")
+	}
+}
+
+func TestMetricsPrometheus(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/metrics/prometheus?name=jvm_memory_bytes_used",
+			code:     200,
+			body:     "# HELP test\n",
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.MetricsPrometheus([]string{"jvm_memory_bytes_used"})
+	if err != nil {
+		t.Error(err)
+	}
+	if resp == "" {
+		t.Error("Expected metrics response to have a value")
+	}
+}

--- a/vinyldns/health_test.go
+++ b/vinyldns/health_test.go
@@ -85,3 +85,18 @@ func TestMetricsPrometheus(t *testing.T) {
 		t.Error("Expected metrics response to have a value")
 	}
 }
+
+func TestHealthError(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/health",
+			code:     500,
+			body:     `{"error":"unhealthy"}`,
+		},
+	})
+	defer server.Close()
+
+	if err := client.Health(); err == nil {
+		t.Error("Expected health error")
+	}
+}

--- a/vinyldns/health_test.go
+++ b/vinyldns/health_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -42,7 +42,6 @@ func superUser() *Client {
 	})
 }
 
-
 func TestGroupCreateIntegration(t *testing.T) {
 	c := client()
 	users := []User{
@@ -744,7 +743,7 @@ func TestZoneACLRuleCreateDeleteIntegration(t *testing.T) {
 		AccessLevel: "Read",
 		Description: "Integration test ACL rule",
 		RecordTypes: []string{"A", "AAAA"},
-		GroupID: groups[0].ID,
+		GroupID:     groups[0].ID,
 	}
 
 	createResp, err := c.ZoneACLRuleCreate(zoneID, rule)
@@ -1169,7 +1168,7 @@ func TestBatchRecordChangeRejectIntegration(t *testing.T) {
 			return
 		}
 
-		if fetchedBatch.Status == "PendingReview"{
+		if fetchedBatch.Status == "PendingReview" {
 			break
 		}
 		if i == (limit - 1) {
@@ -1191,7 +1190,6 @@ func TestBatchRecordChangeRejectIntegration(t *testing.T) {
 		t.Errorf("Expected batch change status to be 'Rejected', got: %s", fetchedBatch.Status)
 	}
 }
-
 
 func TestZoneDeleteIntegration(t *testing.T) {
 	c := client()
@@ -1238,7 +1236,6 @@ func TestZonesDeletedIntegration(t *testing.T) {
 		t.Error("Expected ZonesDeleted to return a non-nil response")
 	}
 }
-
 
 func TestGroupDeleteIntegration(t *testing.T) {
 	c := client()

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -2,7 +2,7 @@
 // +build integration
 
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -542,7 +542,6 @@ func TestRecordSetChangesFailureIntegration(t *testing.T) {
 	failures, err := c.RecordSetChangesFailure(zones[0].ID, ListFilter{})
 	if err != nil {
 		t.Error(err)
-		return
 	}
 
 	// TODO: How to create a failure for testing?
@@ -596,10 +595,8 @@ func TestMetricsPrometheusIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
-	// TODO: Actually validate some metrics content?
 	if metrics == "" {
-		t.Log("Expected MetricsPrometheus to return non-empty metrics")
-		// t.Error("MetricsPrometheus returned empty metrics")
+		t.Error("Expected MetricsPrometheus to return non-empty metrics")
 	}
 }
 
@@ -619,9 +616,6 @@ func TestStatusIntegration(t *testing.T) {
 	}
 	if status.Color == "" {
 		t.Error("Expected Status to return a color")
-	}
-	if status.ProcessingDisabled != true && status.ProcessingDisabled != false {
-		t.Error("Expected Status to return a valid ProcessingDisabled value")
 	}
 	if status.KeyName == "" {
 		t.Error("Expected Status to return a valid KeyName")
@@ -672,7 +666,7 @@ func TestUserIntegration(t *testing.T) {
 		t.Error("Expected User to return a valid ID")
 	}
 
-	if user.GroupID == nil || len(user.GroupID) == 0 {
+	if len(user.GroupID) == 0 {
 		t.Error("Expected User to return at least one GroupID")
 	}
 }
@@ -688,10 +682,9 @@ func TestUserLockUnlockIntegration(t *testing.T) {
 	lockedUser, err := c.UserLock(user.ID)
 	if err != nil {
 		t.Errorf("UserLock failed: %v", err)
-		return
 	}
 
-	if lockedUser.LockStatus != "Locked" && lockedUser.LockStatus != "" {
+	if lockedUser.LockStatus != "Locked" {
 		t.Errorf("User lock status: %s", lockedUser.LockStatus)
 	}
 
@@ -701,7 +694,7 @@ func TestUserLockUnlockIntegration(t *testing.T) {
 		t.Errorf("UserUnlock failed: %v", err)
 	}
 
-	if unlockedUser.LockStatus == "Locked" {
+	if unlockedUser.LockStatus != "Unlocked" {
 		t.Error("Expected user to be unlocked")
 	}
 }
@@ -728,6 +721,10 @@ func TestZoneACLRuleCreateDeleteIntegration(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	if len(groups) == 0 {
+		t.Error("Expected Groups to return at least one group")
+		return
+	}
 	zones, err := c.ZonesListAll(ListFilter{})
 	if err != nil {
 		t.Error(err)
@@ -735,6 +732,7 @@ func TestZoneACLRuleCreateDeleteIntegration(t *testing.T) {
 
 	if len(zones) == 0 {
 		t.Error("No zones available for ACL rule testing")
+		return
 	}
 
 	zoneID := zones[0].ID
@@ -749,7 +747,6 @@ func TestZoneACLRuleCreateDeleteIntegration(t *testing.T) {
 	createResp, err := c.ZoneACLRuleCreate(zoneID, rule)
 	if err != nil {
 		t.Errorf("ZoneACLRuleCreate failed: %v", err)
-		return
 	}
 
 	if createResp.Zone.ID != zoneID {
@@ -763,7 +760,6 @@ func TestZoneACLRuleCreateDeleteIntegration(t *testing.T) {
 	deleteResp, err := c.ZoneACLRuleDelete(zoneID, rule)
 	if err != nil {
 		t.Errorf("ZoneACLRuleDelete failed: %v", err)
-		return
 	}
 
 	if deleteResp.Zone.ID != zoneID {
@@ -802,6 +798,7 @@ func TestRecordSetCountIntegration(t *testing.T) {
 
 	if len(zones) == 0 {
 		t.Error("No zones available for record set count testing")
+		return
 	}
 
 	count, err := c.RecordSetCount(zones[0].ID)
@@ -824,6 +821,7 @@ func TestRecordSetChangeHistoryIntegration(t *testing.T) {
 
 	if len(zones) == 0 {
 		t.Error("No zones available for change history testing")
+		return
 	}
 
 	recordSets, err := c.RecordSetsListAll(zones[0].ID, ListFilter{})
@@ -833,6 +831,7 @@ func TestRecordSetChangeHistoryIntegration(t *testing.T) {
 
 	if len(recordSets) == 0 {
 		t.Error("No record sets available for change history testing")
+		return
 	}
 
 	// Use FQDN format for the filter
@@ -862,7 +861,6 @@ func TestRecordSetOwnershipTransferIntegration(t *testing.T) {
 	groups, err := c.Groups()
 	if err != nil {
 		t.Error(err)
-		return
 	}
 
 	if len(groups) < 2 {
@@ -873,7 +871,6 @@ func TestRecordSetOwnershipTransferIntegration(t *testing.T) {
 	zones, err := c.ZonesListAll(ListFilter{})
 	if err != nil {
 		t.Error(err)
-		return
 	}
 
 	if len(zones) == 0 {
@@ -895,7 +892,6 @@ func TestRecordSetOwnershipTransferIntegration(t *testing.T) {
 	createResp, err := c.RecordSetCreate(recordSet)
 	if err != nil {
 		t.Errorf("Failed to create test record set: %v", err)
-		return
 	}
 
 	createdRecordSetID := createResp.RecordSet.ID
@@ -912,7 +908,6 @@ func TestRecordSetOwnershipTransferIntegration(t *testing.T) {
 
 		if i == (limit - 1) {
 			t.Errorf("Failed to fetch created record set after %d retries", limit)
-			return
 		}
 	}
 
@@ -925,7 +920,6 @@ func TestRecordSetOwnershipTransferIntegration(t *testing.T) {
 		if cleanupErr != nil {
 			t.Logf("Failed to clean up test record set: %v", cleanupErr)
 		}
-		return
 	}
 
 	if transferResp.RecordSet.ID != createdRecordSetID {
@@ -963,6 +957,7 @@ func TestGroupChangeIntegration(t *testing.T) {
 	user, err := c.User("ok")
 	if err != nil {
 		t.Error(err)
+		return
 	}
 	gID := user.GroupID[0]
 	group, err := c.Group(gID)
@@ -984,6 +979,7 @@ func TestGroupChangeIntegration(t *testing.T) {
 
 	if len(activity.Changes) == 0 {
 		t.Error("No group changes available for testing")
+		return
 	}
 
 	changeID := activity.Changes[0].ID
@@ -1041,6 +1037,7 @@ func TestBatchRecordChangeWorkflowIntegration(t *testing.T) {
 
 	if len(zones) == 0 {
 		t.Error("No zones available for batch change testing")
+		return
 	}
 
 	batchChange := &BatchRecordChange{
@@ -1062,7 +1059,6 @@ func TestBatchRecordChangeWorkflowIntegration(t *testing.T) {
 	createResp, err := c.BatchRecordChangeCreate(batchChange)
 	if err != nil {
 		t.Errorf("Failed to create batch change: %v", err)
-		return
 	}
 
 	batchChangeID := createResp.ID
@@ -1103,6 +1099,11 @@ func TestBatchRecordChangeWorkflowIntegration(t *testing.T) {
 					t.Errorf("Batch change approve/cancel failed: %v", cancelErr)
 					return
 				}
+				fetchedBatch, err = c.BatchRecordChange(batchChangeID)
+				if err != nil {
+					t.Errorf("Failed to fetch batch change after cancel: %v", err)
+					return
+				}
 				if fetchedBatch.Status != "Cancelled" {
 					t.Error("Expected batch change to be cancelled")
 					return
@@ -1123,7 +1124,6 @@ func TestBatchRecordChangeRejectIntegration(t *testing.T) {
 	zones, err := c.ZonesListAll(ListFilter{})
 	if err != nil {
 		t.Error(err)
-		return
 	}
 
 	if len(zones) == 0 {
@@ -1150,7 +1150,6 @@ func TestBatchRecordChangeRejectIntegration(t *testing.T) {
 	createResp, err := c.BatchRecordChangeCreate(batchChange)
 	if err != nil {
 		t.Errorf("Failed to create batch change: %v", err)
-		return
 	}
 
 	batchChangeID := createResp.ID

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -17,6 +17,7 @@ package vinyldns
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -31,6 +32,16 @@ func client() *Client {
 		"go-vinyldns integration testing",
 	})
 }
+
+func superUser() *Client {
+	return NewClient(ClientConfiguration{
+		"superUserAccessKey",
+		"superUserSecretKey",
+		"http://localhost:9000",
+		"go-vinyldns integration testing (super user)",
+	})
+}
+
 
 func TestGroupCreateIntegration(t *testing.T) {
 	c := client()
@@ -174,6 +185,10 @@ func TestZoneByNameIntegration(t *testing.T) {
 	if z.Name != "ok." {
 		t.Error(fmt.Sprintf("unable to get ZoneByName %s", "ok."))
 	}
+	if z.AdminGroupID == "" {
+		t.Error("expected ZoneByName to return a zone with a valid AdminGroupID")
+	}
+
 }
 
 func TestZonesListAllIntegrationFilterForNonexistentName(t *testing.T) {
@@ -512,6 +527,672 @@ func TestRecordSetChangesListAllIntegration(t *testing.T) {
 	}
 }
 
+func TestRecordSetChangesFailureIntegration(t *testing.T) {
+	c := client()
+
+	zones, err := c.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(zones) == 0 {
+		t.Error("Expected at least one zone for RecordSetChangesFailure testing")
+		return
+	}
+
+	failures, err := c.RecordSetChangesFailure(zones[0].ID, ListFilter{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// TODO: How to create a failure for testing?
+	if failures == nil {
+		t.Error("Expected RecordSetChangesFailure to return a non-nil response")
+	}
+}
+
+// ==============================================================================
+// Health & Monitoring Tests
+// ==============================================================================
+
+func TestPingIntegration(t *testing.T) {
+	c := client()
+	response, err := c.Ping()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !strings.Contains(response, "PONG") {
+		t.Errorf("Expected Ping to return 'PONG', got: %s", response)
+	}
+}
+
+func TestHealthIntegration(t *testing.T) {
+	c := client()
+	err := c.Health()
+	if err != nil {
+		t.Errorf("Health check failed: %v", err)
+	}
+}
+
+func TestColorIntegration(t *testing.T) {
+	c := client()
+	color, err := c.Color()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if color == "" {
+		t.Error("Expected Color to return a non-empty value")
+	} else if color != "green" && color != "blue" {
+		t.Errorf("Expected Color to return 'green' or 'blue', got: %s", color)
+	}
+}
+
+func TestMetricsPrometheusIntegration(t *testing.T) {
+	c := client()
+	metrics, err := c.MetricsPrometheus(nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// TODO: Actually validate some metrics content?
+	if metrics == "" {
+		t.Log("Expected MetricsPrometheus to return non-empty metrics")
+		// t.Error("MetricsPrometheus returned empty metrics")
+	}
+}
+
+// ==============================================================================
+// System Management Tests
+// ==============================================================================
+
+func TestStatusIntegration(t *testing.T) {
+	c := client()
+	status, err := c.Status()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if status.Version == "" {
+		t.Error("Expected Status to return a version")
+	}
+	if status.Color == "" {
+		t.Error("Expected Status to return a color")
+	}
+	if status.ProcessingDisabled != true && status.ProcessingDisabled != false {
+		t.Error("Expected Status to return a valid ProcessingDisabled value")
+	}
+	if status.KeyName == "" {
+		t.Error("Expected Status to return a valid KeyName")
+	}
+}
+
+func TestStatusUpdateIntegration(t *testing.T) {
+	c := superUser()
+
+	currentStatus, err := c.Status()
+	if err != nil {
+		t.Error(err)
+	}
+
+	newDisabledState := !currentStatus.ProcessingDisabled
+	updatedStatus, err := c.StatusUpdate(newDisabledState)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if updatedStatus.ProcessingDisabled != newDisabledState {
+		t.Errorf("Expected ProcessingDisabled to be %v, got %v", newDisabledState, updatedStatus.ProcessingDisabled)
+	}
+
+	// Restore original state
+	_, err = c.StatusUpdate(currentStatus.ProcessingDisabled)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// ==============================================================================
+// User Management Tests
+// ==============================================================================
+
+func TestUserIntegration(t *testing.T) {
+	c := client()
+	user, err := c.User("ok")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if user.UserName != "ok" {
+		t.Errorf("Expected user name to be 'ok', got: %s", user.UserName)
+	}
+
+	if user.ID == "" {
+		t.Error("Expected User to return a valid ID")
+	}
+
+	if user.GroupID == nil || len(user.GroupID) == 0 {
+		t.Error("Expected User to return at least one GroupID")
+	}
+}
+
+func TestUserLockUnlockIntegration(t *testing.T) {
+	c := superUser()
+
+	user, err := c.User("ok")
+	if err != nil {
+		t.Error(err)
+	}
+
+	lockedUser, err := c.UserLock(user.ID)
+	if err != nil {
+		t.Errorf("UserLock failed: %v", err)
+		return
+	}
+
+	if lockedUser.LockStatus != "Locked" && lockedUser.LockStatus != "" {
+		t.Errorf("User lock status: %s", lockedUser.LockStatus)
+	}
+
+	// Unlock the user to restore state
+	unlockedUser, err := c.UserUnlock(user.ID)
+	if err != nil {
+		t.Errorf("UserUnlock failed: %v", err)
+	}
+
+	if unlockedUser.LockStatus == "Locked" {
+		t.Error("Expected user to be unlocked")
+	}
+}
+
+// ==============================================================================
+// Zone Enhancement Tests
+// ==============================================================================
+
+func TestZoneBackendIDsIntegration(t *testing.T) {
+	c := client()
+	backendIDs, err := c.ZoneBackendIDs()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(backendIDs) == 0 {
+		t.Error("Expected ZoneBackendIDs to return at least one backend")
+	}
+}
+
+func TestZoneACLRuleCreateDeleteIntegration(t *testing.T) {
+	c := superUser()
+	groups, err := c.Groups()
+	if err != nil {
+		t.Error(err)
+	}
+	zones, err := c.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(zones) == 0 {
+		t.Error("No zones available for ACL rule testing")
+	}
+
+	zoneID := zones[0].ID
+
+	rule := &ACLRule{
+		AccessLevel: "Read",
+		Description: "Integration test ACL rule",
+		RecordTypes: []string{"A", "AAAA"},
+		GroupID: groups[0].ID,
+	}
+
+	createResp, err := c.ZoneACLRuleCreate(zoneID, rule)
+	if err != nil {
+		t.Errorf("ZoneACLRuleCreate failed: %v", err)
+		return
+	}
+
+	if createResp.Zone.ID != zoneID {
+		t.Error("Expected ZoneACLRuleCreate to return the correct zone ID")
+	}
+
+	if createResp.Status != "Accepted" && createResp.Status != "Pending" {
+		t.Errorf("Expected ZoneACLRuleCreate to return status 'Accepted' or 'Pending', got: %s", createResp.Status)
+	}
+
+	deleteResp, err := c.ZoneACLRuleDelete(zoneID, rule)
+	if err != nil {
+		t.Errorf("ZoneACLRuleDelete failed: %v", err)
+		return
+	}
+
+	if deleteResp.Zone.ID != zoneID {
+		t.Error("Expected ZoneACLRuleDelete to return the correct zone ID")
+	}
+
+	if deleteResp.Status != "Accepted" && deleteResp.Status != "Pending" {
+		t.Errorf("Expected ZoneACLRuleDelete to return status 'Accepted' or 'Pending', got: %s", deleteResp.Status)
+	}
+}
+
+func TestZoneChangesFailureIntegration(t *testing.T) {
+	c := client()
+	failures, err := c.ZoneChangesFailure(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// It's okay if there are no failures
+	if failures == nil {
+		t.Error("Expected ZoneChangesFailure to return a non-nil response")
+	}
+}
+
+// ==============================================================================
+// Record Set Enhancement Tests
+// ==============================================================================
+
+func TestRecordSetCountIntegration(t *testing.T) {
+	c := client()
+
+	zones, err := c.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(zones) == 0 {
+		t.Error("No zones available for record set count testing")
+	}
+
+	count, err := c.RecordSetCount(zones[0].ID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if count.Count < 0 {
+		t.Error("Expected RecordSetCount to return a non-negative count")
+	}
+}
+
+func TestRecordSetChangeHistoryIntegration(t *testing.T) {
+	c := client()
+
+	zones, err := c.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(zones) == 0 {
+		t.Error("No zones available for change history testing")
+	}
+
+	recordSets, err := c.RecordSetsListAll(zones[0].ID, ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(recordSets) == 0 {
+		t.Error("No record sets available for change history testing")
+	}
+
+	// Use FQDN format for the filter
+	fqdn := recordSets[0].Name
+	if !strings.HasSuffix(fqdn, ".") && zones[0].Name != "" {
+		fqdn = recordSets[0].Name + "." + zones[0].Name
+	}
+
+	filter := RecordSetChangeHistoryFilter{
+		ZoneID: zones[0].ID,
+		FQDN:   fqdn,
+	}
+
+	history, err := c.RecordSetChangeHistory(filter)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if history == nil {
+		t.Error("Expected RecordSetChangeHistory to return a non-nil response")
+	}
+}
+
+func TestRecordSetOwnershipTransferIntegration(t *testing.T) {
+	c := client()
+
+	groups, err := c.Groups()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if len(groups) < 2 {
+		t.Error("Expected at least 2 groups for ownership transfer testing")
+		return
+	}
+
+	zones, err := c.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if len(zones) == 0 {
+		t.Error("Expected at least one zone for ownership transfer testing")
+		return
+	}
+
+	recordSet := &RecordSet{
+		Name:   "ownership-transfer-test",
+		ZoneID: zones[0].ID,
+		Type:   "A",
+		TTL:    60,
+		Records: []Record{
+			{Address: "127.0.0.1"},
+		},
+		OwnerGroupID: groups[0].ID,
+	}
+
+	createResp, err := c.RecordSetCreate(recordSet)
+	if err != nil {
+		t.Errorf("Failed to create test record set: %v", err)
+		return
+	}
+
+	createdRecordSetID := createResp.RecordSet.ID
+
+	limit := 10
+	var fetchedRecordSet RecordSet
+	for i := 0; i < limit; i++ {
+		time.Sleep(5 * time.Second)
+
+		fetchedRecordSet, err = c.RecordSet(zones[0].ID, createdRecordSetID)
+		if err == nil && fetchedRecordSet.ID == createdRecordSetID {
+			break
+		}
+
+		if i == (limit - 1) {
+			t.Errorf("Failed to fetch created record set after %d retries", limit)
+			return
+		}
+	}
+
+	transferResp, err := c.RecordSetOwnershipTransferRequest(&fetchedRecordSet, groups[1].ID)
+	if err != nil {
+		t.Errorf("Ownership transfer request failed: %v", err)
+
+		// Clean up
+		_, cleanupErr := c.RecordSetDelete(zones[0].ID, createdRecordSetID)
+		if cleanupErr != nil {
+			t.Logf("Failed to clean up test record set: %v", cleanupErr)
+		}
+		return
+	}
+
+	if transferResp.RecordSet.ID != createdRecordSetID {
+		t.Error("Expected ownership transfer to return the correct record set ID")
+	}
+
+	// Wait for transfer to be processed
+	time.Sleep(5 * time.Second)
+
+	updatedRecordSet, err := c.RecordSet(zones[0].ID, createdRecordSetID)
+	if err != nil {
+		t.Errorf("Failed to fetch record set after transfer request: %v", err)
+	}
+
+	_, err = c.RecordSetOwnershipTransferCancel(&updatedRecordSet, groups[1].ID)
+	if err != nil {
+		t.Logf("Ownership transfer cancel failed: %v", err)
+	}
+
+	// Clean up - delete the test record set
+	time.Sleep(5 * time.Second)
+	_, err = c.RecordSetDelete(zones[0].ID, createdRecordSetID)
+	if err != nil {
+		t.Errorf("Failed to clean up test record set: %v", err)
+	}
+}
+
+// ==============================================================================
+// Group Enhancement Tests
+// ==============================================================================
+
+func TestGroupChangeIntegration(t *testing.T) {
+	c := client()
+
+	user, err := c.User("ok")
+	if err != nil {
+		t.Error(err)
+	}
+	gID := user.GroupID[0]
+	group, err := c.Group(gID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	group.Description = "Updated description for group change test"
+	_, err = c.GroupUpdate(gID, group)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Get group activity to find a change ID
+	activity, err := c.GroupActivity(gID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(activity.Changes) == 0 {
+		t.Error("No group changes available for testing")
+	}
+
+	changeID := activity.Changes[0].ID
+	groupChange, err := c.GroupChange(changeID)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if groupChange.ID != changeID {
+		t.Errorf("Expected group change ID to be %s, got %s", changeID, groupChange.ID)
+		return
+	}
+	if groupChange.ChangeType != "Update" {
+		t.Errorf("Expected group change type to be 'Update', got %s", groupChange.ChangeType)
+	}
+	if groupChange.OldGroup.Description == group.Description {
+		t.Error("Expected group change 'Before' description to differ from updated description")
+	}
+	if groupChange.NewGroup.Description != group.Description {
+		t.Error("Expected group change 'After' description to match updated description")
+	}
+}
+
+func TestGroupValidDomainsIntegration(t *testing.T) {
+	c := client()
+
+	domains, err := c.GroupValidDomains()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if domains == nil {
+		t.Error("Expected GroupValidDomains to return a non-nil response")
+	}
+
+	for _, domain := range domains {
+		if domain == "" {
+			t.Error("Expected valid domains to be non-empty strings")
+		}
+	}
+}
+
+// ==============================================================================
+// Batch Changes Enhancement Tests
+// ==============================================================================
+
+func TestBatchRecordChangeWorkflowIntegration(t *testing.T) {
+	c := client()
+
+	zones, err := c.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(zones) == 0 {
+		t.Error("No zones available for batch change testing")
+	}
+
+	batchChange := &BatchRecordChange{
+		Comments: "Integration test batch change",
+		Changes: []RecordChange{
+			{
+				ChangeType: "Add",
+				InputName:  "batch-test." + zones[0].Name,
+				Type:       "A",
+				TTL:        300,
+				Record: RecordData{
+					Address: "127.0.0.1",
+				},
+			},
+		},
+		OwnerGroupID: zones[0].AdminGroupID,
+	}
+
+	createResp, err := c.BatchRecordChangeCreate(batchChange)
+	if err != nil {
+		t.Errorf("Failed to create batch change: %v", err)
+		return
+	}
+
+	batchChangeID := createResp.ID
+
+	limit := 10
+	for i := 0; i < limit; i++ {
+		time.Sleep(5 * time.Second)
+
+		fetchedBatch, err := c.BatchRecordChange(batchChangeID)
+		if err != nil {
+			t.Errorf("Failed to fetch batch change: %v", err)
+			break
+		}
+
+		if fetchedBatch.Status == "Complete" {
+			return
+		}
+
+		if fetchedBatch.Status == "Failed" {
+			t.Errorf("Batch change failed, status: %s", fetchedBatch.Status)
+			return
+		}
+
+		// If in manual review, try to approve/cancel
+		if fetchedBatch.Status == "PendingReview" {
+			// Try to approve
+			review := &BatchChangeReview{
+				ReviewComment: "Integration test approval",
+			}
+
+			_, approveErr := c.BatchRecordChangeApprove(batchChangeID, review)
+			if approveErr != nil {
+				t.Logf("Batch change approve failed: %v", approveErr)
+
+				// Try to cancel instead
+				_, cancelErr := c.BatchRecordChangeCancel(batchChangeID, review)
+				if cancelErr != nil {
+					t.Errorf("Batch change approve/cancel failed: %v", cancelErr)
+					return
+				}
+				if fetchedBatch.Status != "Cancelled" {
+					t.Error("Expected batch change to be cancelled")
+					return
+				}
+			}
+		}
+
+		if i == (limit - 1) {
+			t.Errorf("Batch change did not complete after %d retries, status: %s", limit, fetchedBatch.Status)
+		}
+	}
+}
+
+// Note: This test is skipped if manual review is not enabled in the environment
+func TestBatchRecordChangeRejectIntegration(t *testing.T) {
+	c := client()
+
+	zones, err := c.ZonesListAll(ListFilter{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if len(zones) == 0 {
+		t.Error("No zones available for batch change testing")
+		return
+	}
+
+	batchChange := &BatchRecordChange{
+		Comments: "Integration test batch change",
+		Changes: []RecordChange{
+			{
+				ChangeType: "Add",
+				InputName:  "batch-test-reject." + zones[0].Name,
+				Type:       "A",
+				TTL:        300,
+				Record: RecordData{
+					Address: "127.0.0.2",
+				},
+			},
+		},
+		OwnerGroupID: zones[0].AdminGroupID,
+	}
+
+	createResp, err := c.BatchRecordChangeCreate(batchChange)
+	if err != nil {
+		t.Errorf("Failed to create batch change: %v", err)
+		return
+	}
+
+	batchChangeID := createResp.ID
+	limit := 10
+	for i := 0; i < limit; i++ {
+		time.Sleep(5 * time.Second)
+		fetchedBatch, err := c.BatchRecordChange(batchChangeID)
+		if err != nil {
+			t.Errorf("Failed to fetch batch change: %v", err)
+			break
+		}
+
+		if fetchedBatch.Status == "Complete" || fetchedBatch.Status == "Failed" {
+			t.Skip("Batch change completed without review. Manual review is not enabled")
+			return
+		}
+
+		if fetchedBatch.Status == "PendingReview"{
+			break
+		}
+		if i == (limit - 1) {
+			t.Errorf("Batch change did not complete/reach manual review after %d retries, status: %s", limit, fetchedBatch.Status)
+		}
+	}
+	review := &BatchChangeReview{
+		ReviewComment: "Integration test rejection",
+	}
+	_, err = c.BatchRecordChangeReject(batchChangeID, review)
+	if err != nil {
+		t.Errorf("Failed to reject batch change: %v", err)
+	}
+	fetchedBatch, err := c.BatchRecordChange(batchChangeID)
+	if err != nil {
+		t.Errorf("Failed to fetch batch change after rejection: %v", err)
+	}
+	if fetchedBatch.Status != "Rejected" {
+		t.Errorf("Expected batch change status to be 'Rejected', got: %s", fetchedBatch.Status)
+	}
+}
+
+
 func TestZoneDeleteIntegration(t *testing.T) {
 	c := client()
 	zs, err := c.ZonesListAll(ListFilter{})
@@ -545,6 +1226,19 @@ func TestZoneDeleteIntegration(t *testing.T) {
 		}
 	}
 }
+
+func TestZonesDeletedIntegration(t *testing.T) {
+	c := client()
+	deletedZones, err := c.ZonesDeleted(DeletedZonesFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if deletedZones == nil {
+		t.Error("Expected ZonesDeleted to return a non-nil response")
+	}
+}
+
 
 func TestGroupDeleteIntegration(t *testing.T) {
 	c := client()

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -841,8 +841,9 @@ func TestRecordSetChangeHistoryIntegration(t *testing.T) {
 	}
 
 	filter := RecordSetChangeHistoryFilter{
-		ZoneID: zones[0].ID,
-		FQDN:   fqdn,
+		ZoneID:     zones[0].ID,
+		FQDN:       fqdn,
+		RecordType: recordSets[0].Type,
 	}
 
 	history, err := c.RecordSetChangeHistory(filter)

--- a/vinyldns/integration_test.go
+++ b/vinyldns/integration_test.go
@@ -2,7 +2,7 @@
 // +build integration
 
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/mock_testing_server_test.go
+++ b/vinyldns/mock_testing_server_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/mock_testing_server_test.go
+++ b/vinyldns/mock_testing_server_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -208,6 +208,43 @@ func (c *Client) RecordSetUpdate(rs *RecordSet) (*RecordSetUpdateResponse, error
 	return resource, nil
 }
 
+// RecordSetOwnershipTransferRequest requests ownership transfer for a record set.
+func (c *Client) RecordSetOwnershipTransferRequest(rs *RecordSet, requestedOwnerGroupID string) (*RecordSetUpdateResponse, error) {
+	return c.recordSetOwnershipTransfer(rs, OwnershipTransferStatusRequested, requestedOwnerGroupID, false)
+}
+
+// RecordSetOwnershipTransferApprove approves a pending ownership transfer request.
+func (c *Client) RecordSetOwnershipTransferApprove(rs *RecordSet, requestedOwnerGroupID string) (*RecordSetUpdateResponse, error) {
+	return c.recordSetOwnershipTransfer(rs, OwnershipTransferStatusManuallyApproved, requestedOwnerGroupID, true)
+}
+
+// RecordSetOwnershipTransferReject rejects a pending ownership transfer request.
+func (c *Client) RecordSetOwnershipTransferReject(rs *RecordSet, requestedOwnerGroupID string) (*RecordSetUpdateResponse, error) {
+	return c.recordSetOwnershipTransfer(rs, OwnershipTransferStatusManuallyRejected, requestedOwnerGroupID, false)
+}
+
+// RecordSetOwnershipTransferCancel cancels a pending ownership transfer request.
+func (c *Client) RecordSetOwnershipTransferCancel(rs *RecordSet, requestedOwnerGroupID string) (*RecordSetUpdateResponse, error) {
+	return c.recordSetOwnershipTransfer(rs, OwnershipTransferStatusCancelled, requestedOwnerGroupID, false)
+}
+
+func (c *Client) recordSetOwnershipTransfer(rs *RecordSet, status OwnershipTransferStatus, requestedOwnerGroupID string, updateOwnerGroup bool) (*RecordSetUpdateResponse, error) {
+	if rs == nil {
+		return nil, fmt.Errorf("record set is required")
+	}
+
+	if updateOwnerGroup && requestedOwnerGroupID != "" {
+		rs.OwnerGroupID = requestedOwnerGroupID
+	}
+
+	rs.RecordSetGroupChange = &OwnershipTransfer{
+		OwnershipTransferStatus: status,
+		RequestedOwnerGroupID:   requestedOwnerGroupID,
+	}
+
+	return c.RecordSetUpdate(rs)
+}
+
 // RecordSetDelete deletes the RecordSet matching the Zone ID and RecordSet ID it's passed.
 func (c *Client) RecordSetDelete(zoneID, recordSetID string) (*RecordSetUpdateResponse, error) {
 	resource := &RecordSetUpdateResponse{}

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -167,6 +167,17 @@ func (c *Client) RecordSet(zoneID, recordSetID string) (RecordSet, error) {
 	return rs.RecordSet, nil
 }
 
+// RecordSetCount retrieves the count of record sets in a zone.
+func (c *Client) RecordSetCount(zoneID string) (RecordSetCount, error) {
+	count := &RecordSetCount{}
+	err := resourceRequest(c, recordSetCountEP(c, zoneID), "GET", nil, count)
+	if err != nil {
+		return RecordSetCount{}, err
+	}
+
+	return *count, nil
+}
+
 // RecordSetCreate creates the RecordSet it's passed in the Zone whose ID it's passed.
 func (c *Client) RecordSetCreate(rs *RecordSet) (*RecordSetUpdateResponse, error) {
 	rsJSON, err := json.Marshal(rs)
@@ -219,6 +230,17 @@ func (c *Client) RecordSetChanges(zoneID string, f ListFilterRecordSetChanges) (
 	return rsc, nil
 }
 
+// RecordSetChangeHistory retrieves history for a record set.
+func (c *Client) RecordSetChangeHistory(f RecordSetChangeHistoryFilter) (*RecordSetChanges, error) {
+	rsc := &RecordSetChanges{}
+	err := resourceRequest(c, recordSetChangeHistoryEP(c, f), "GET", nil, rsc)
+	if err != nil {
+		return &RecordSetChanges{}, err
+	}
+
+	return rsc, nil
+}
+
 // RecordSetChangesListAll retrieves the complete list of record set changes for the Zone ListFilter criteria passed.
 // Handles paging through results on the user's behalf.
 func (c *Client) RecordSetChangesListAll(zoneID string, filter ListFilterRecordSetChanges) ([]RecordSetChange, error) {
@@ -253,4 +275,15 @@ func (c *Client) RecordSetChange(zoneID, recordSetID, changeID string) (*RecordS
 	}
 
 	return rsc, nil
+}
+
+// RecordSetChangesFailure retrieves failed record set changes for a zone.
+func (c *Client) RecordSetChangesFailure(zoneID string, filter ListFilter) (*RecordSetChangeFailuresResponse, error) {
+	failures := &RecordSetChangeFailuresResponse{}
+	err := resourceRequest(c, recordSetChangesFailureEP(c, zoneID, filter), "GET", nil, failures)
+	if err != nil {
+		return &RecordSetChangeFailuresResponse{}, err
+	}
+
+	return failures, nil
 }

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/recordsets.go
+++ b/vinyldns/recordsets.go
@@ -233,16 +233,18 @@ func (c *Client) recordSetOwnershipTransfer(rs *RecordSet, status OwnershipTrans
 		return nil, fmt.Errorf("record set is required")
 	}
 
+	copyRS := *rs
+
 	if updateOwnerGroup && requestedOwnerGroupID != "" {
-		rs.OwnerGroupID = requestedOwnerGroupID
+		copyRS.OwnerGroupID = requestedOwnerGroupID
 	}
 
-	rs.RecordSetGroupChange = &OwnershipTransfer{
+	copyRS.RecordSetGroupChange = &OwnershipTransfer{
 		OwnershipTransferStatus: status,
 		RequestedOwnerGroupID:   requestedOwnerGroupID,
 	}
 
-	return c.RecordSetUpdate(rs)
+	return c.RecordSetUpdate(&copyRS)
 }
 
 // RecordSetDelete deletes the RecordSet matching the Zone ID and RecordSet ID it's passed.
@@ -269,6 +271,10 @@ func (c *Client) RecordSetChanges(zoneID string, f ListFilterRecordSetChanges) (
 
 // RecordSetChangeHistory retrieves history for a record set.
 func (c *Client) RecordSetChangeHistory(f RecordSetChangeHistoryFilter) (*RecordSetChanges, error) {
+	if f.ZoneID == "" || f.FQDN == "" || f.RecordType == "" {
+		return nil, fmt.Errorf("zone ID, FQDN, and record type are required")
+	}
+
 	rsc := &RecordSetChanges{}
 	err := resourceRequest(c, recordSetChangeHistoryEP(c, f), "GET", nil, rsc)
 	if err != nil {

--- a/vinyldns/recordsets_extra_resources.go
+++ b/vinyldns/recordsets_extra_resources.go
@@ -12,13 +12,15 @@ limitations under the License.
 
 package vinyldns
 
-// groupsList retrieves the list of zones with the List criteria passed.
-func (c *Client) groupsList(filter ListFilter) (*Groups, error) {
-	groups := &Groups{}
-	err := resourceRequest(c, groupsListEP(c, filter), "GET", nil, groups)
-	if err != nil {
-		return groups, err
-	}
+// RecordSetCount represents the record set count response.
+type RecordSetCount struct {
+	Count int `json:"count"`
+}
 
-	return groups, nil
+// RecordSetChangeFailuresResponse represents failed record set changes.
+type RecordSetChangeFailuresResponse struct {
+	FailedRecordSetChanges []RecordSetChange `json:"failedRecordSetChanges"`
+	StartFrom              int               `json:"startFrom,omitempty"`
+	NextID                 int               `json:"nextId,omitempty"`
+	MaxItems               int               `json:"maxItems,omitempty"`
 }

--- a/vinyldns/recordsets_extra_resources.go
+++ b/vinyldns/recordsets_extra_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/recordsets_extra_test.go
+++ b/vinyldns/recordsets_extra_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import "testing"
+
+func TestRecordSetCount(t *testing.T) {
+	countJSON := `{"count": 10}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/zones/123/recordsetcount",
+			code:     200,
+			body:     countJSON,
+		},
+	})
+	defer server.Close()
+
+	count, err := client.RecordSetCount("123")
+	if err != nil {
+		t.Error(err)
+	}
+	if count.Count != 10 {
+		t.Error("Expected record set count to be 10")
+	}
+}
+
+func TestRecordSetChangeHistory(t *testing.T) {
+	historyJSON := `{
+		"zoneId": "z1",
+		"recordSetChanges": [
+			{
+				"zone": {"name": "ok.", "email": "test@test.com", "status": "Active", "id": "z1"},
+				"recordSet": {"name": "ok.", "type": "A", "zoneId": "z1", "ttl": 300, "id": "rs1", "account": "system", "records": []},
+				"userId": "u1",
+				"changeType": "Update",
+				"status": "Complete",
+				"created": "now",
+				"id": "c1",
+				"userName": "testuser"
+			}
+		],
+		"maxItems": 100
+	}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/recordsetchange/history?fqdn=ok.&recordType=A&zoneId=z1",
+			code:     200,
+			body:     historyJSON,
+		},
+	})
+	defer server.Close()
+
+	history, err := client.RecordSetChangeHistory(RecordSetChangeHistoryFilter{
+		ZoneID:     "z1",
+		FQDN:       "ok.",
+		RecordType: "A",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(history.RecordSetChanges) != 1 {
+		t.Error("Expected record set changes to have one entry")
+	}
+}
+
+func TestRecordSetChangesFailure(t *testing.T) {
+	failuresJSON := `{
+		"failedRecordSetChanges": [
+			{
+				"zone": {"name": "ok.", "email": "test@test.com", "status": "Active", "id": "z1"},
+				"recordSet": {"name": "ok.", "type": "A", "zoneId": "z1", "ttl": 300, "id": "rs1", "account": "system", "records": []},
+				"userId": "u1",
+				"changeType": "Create",
+				"status": "Failed",
+				"created": "now",
+				"id": "c1"
+			}
+		],
+		"maxItems": 100
+	}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/metrics/health/zones/z1/recordsetchangesfailure",
+			code:     200,
+			body:     failuresJSON,
+		},
+	})
+	defer server.Close()
+
+	failures, err := client.RecordSetChangesFailure("z1", ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(failures.FailedRecordSetChanges) != 1 {
+		t.Error("Expected failed record set changes to have one entry")
+	}
+}

--- a/vinyldns/recordsets_extra_test.go
+++ b/vinyldns/recordsets_extra_test.go
@@ -73,6 +73,16 @@ func TestRecordSetChangeHistory(t *testing.T) {
 	}
 }
 
+func TestRecordSetChangeHistoryRequiresFields(t *testing.T) {
+	server, client := testTools(nil)
+	defer server.Close()
+
+	_, err := client.RecordSetChangeHistory(RecordSetChangeHistoryFilter{})
+	if err == nil {
+		t.Fatal("expected error for missing record set change history fields")
+	}
+}
+
 func TestRecordSetChangesFailure(t *testing.T) {
 	failuresJSON := `{
 		"failedRecordSetChanges": [

--- a/vinyldns/recordsets_extra_test.go
+++ b/vinyldns/recordsets_extra_test.go
@@ -83,6 +83,26 @@ func TestRecordSetChangeHistoryRequiresFields(t *testing.T) {
 	}
 }
 
+func TestRecordSetChangeHistoryError(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/recordsetchange/history?zoneId=z1&fqdn=ok.&recordType=A",
+			code:     500,
+			body:     `{"error":"failed"}`,
+		},
+	})
+	defer server.Close()
+
+	_, err := client.RecordSetChangeHistory(RecordSetChangeHistoryFilter{
+		ZoneID:     "z1",
+		FQDN:       "ok.",
+		RecordType: "A",
+	})
+	if err == nil {
+		t.Error("Expected record set change history error")
+	}
+}
+
 func TestRecordSetChangesFailure(t *testing.T) {
 	failuresJSON := `{
 		"failedRecordSetChanges": [

--- a/vinyldns/recordsets_extra_test.go
+++ b/vinyldns/recordsets_extra_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/recordsets_helpers.go
+++ b/vinyldns/recordsets_helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/recordsets_helpers.go
+++ b/vinyldns/recordsets_helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/recordsets_ownership_test.go
+++ b/vinyldns/recordsets_ownership_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestRecordSetOwnershipTransferRequest(t *testing.T) {
+	body := runOwnershipTransferTest(t, OwnershipTransferStatusRequested, false)
+
+	if !bytes.Contains(body, []byte(`"ownershipTransferStatus":"Requested"`)) {
+		t.Error("expected ownershipTransferStatus to be Requested")
+	}
+	if !bytes.Contains(body, []byte(`"requestedOwnerGroupId":"requested-group-id"`)) {
+		t.Error("expected requestedOwnerGroupId in request body")
+	}
+	if !bytes.Contains(body, []byte(`"ownerGroupId":"owner-group-id"`)) {
+		t.Error("expected ownerGroupId to remain unchanged for request")
+	}
+}
+
+func TestRecordSetOwnershipTransferApprove(t *testing.T) {
+	body := runOwnershipTransferTest(t, OwnershipTransferStatusManuallyApproved, true)
+
+	if !bytes.Contains(body, []byte(`"ownershipTransferStatus":"ManuallyApproved"`)) {
+		t.Error("expected ownershipTransferStatus to be ManuallyApproved")
+	}
+	if !bytes.Contains(body, []byte(`"requestedOwnerGroupId":"requested-group-id"`)) {
+		t.Error("expected requestedOwnerGroupId in request body")
+	}
+	if !bytes.Contains(body, []byte(`"ownerGroupId":"requested-group-id"`)) {
+		t.Error("expected ownerGroupId to be updated for approve")
+	}
+}
+
+func TestRecordSetOwnershipTransferReject(t *testing.T) {
+	body := runOwnershipTransferTest(t, OwnershipTransferStatusManuallyRejected, false)
+
+	if !bytes.Contains(body, []byte(`"ownershipTransferStatus":"ManuallyRejected"`)) {
+		t.Error("expected ownershipTransferStatus to be ManuallyRejected")
+	}
+	if !bytes.Contains(body, []byte(`"requestedOwnerGroupId":"requested-group-id"`)) {
+		t.Error("expected requestedOwnerGroupId in request body")
+	}
+}
+
+func TestRecordSetOwnershipTransferCancel(t *testing.T) {
+	body := runOwnershipTransferTest(t, OwnershipTransferStatusCancelled, false)
+
+	if !bytes.Contains(body, []byte(`"ownershipTransferStatus":"Cancelled"`)) {
+		t.Error("expected ownershipTransferStatus to be Cancelled")
+	}
+	if !bytes.Contains(body, []byte(`"requestedOwnerGroupId":"requested-group-id"`)) {
+		t.Error("expected requestedOwnerGroupId in request body")
+	}
+}
+
+func runOwnershipTransferTest(t *testing.T, status OwnershipTransferStatus, updateOwnerGroup bool) []byte {
+	t.Helper()
+
+	recordSetUpdateResponseJSON, err := readFile("test-fixtures/recordsets/recordset-update.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var body []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI != "/zones/123/recordsets/456" {
+			t.Fatalf("unexpected endpoint %s", r.RequestURI)
+		}
+
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, recordSetUpdateResponseJSON)
+	}))
+	defer server.Close()
+
+	client := newOwnershipTransferClient(server.URL)
+
+	rs := &RecordSet{
+		ZoneID:       "123",
+		ID:           "456",
+		Name:         "name",
+		Type:         "CNAME",
+		TTL:          200,
+		OwnerGroupID: "owner-group-id",
+		Records: []Record{{
+			CName: "cname",
+		}},
+	}
+
+	switch status {
+	case OwnershipTransferStatusRequested:
+		_, err = client.RecordSetOwnershipTransferRequest(rs, "requested-group-id")
+	case OwnershipTransferStatusManuallyApproved:
+		_, err = client.RecordSetOwnershipTransferApprove(rs, "requested-group-id")
+	case OwnershipTransferStatusManuallyRejected:
+		_, err = client.RecordSetOwnershipTransferReject(rs, "requested-group-id")
+	case OwnershipTransferStatusCancelled:
+		_, err = client.RecordSetOwnershipTransferCancel(rs, "requested-group-id")
+	default:
+		t.Fatalf("unexpected ownership transfer status %s", status)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if updateOwnerGroup && !bytes.Contains(body, []byte(`"ownerGroupId":"requested-group-id"`)) {
+		t.Error("expected ownerGroupId to be updated for approval")
+	}
+
+	return body
+}
+
+func newOwnershipTransferClient(serverURL string) *Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return url.Parse(serverURL)
+		},
+	}
+
+	return &Client{
+		AccessKey:  "accessToken",
+		SecretKey:  "secretToken",
+		Host:       "http://host.com",
+		HTTPClient: &http.Client{Transport: tr},
+		UserAgent:  "go-vinyldns testing",
+	}
+}

--- a/vinyldns/recordsets_ownership_test.go
+++ b/vinyldns/recordsets_ownership_test.go
@@ -83,8 +83,8 @@ func runOwnershipTransferTest(t *testing.T, status OwnershipTransferStatus, upda
 
 	var body []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI != "/zones/123/recordsets/456" {
-			t.Fatalf("unexpected endpoint %s", r.RequestURI)
+		if r.URL.Path != "/zones/123/recordsets/456" {
+			t.Fatalf("unexpected endpoint %s", r.URL.Path)
 		}
 
 		body, _ = io.ReadAll(r.Body)

--- a/vinyldns/recordsets_ownership_test.go
+++ b/vinyldns/recordsets_ownership_test.go
@@ -73,6 +73,38 @@ func TestRecordSetOwnershipTransferCancel(t *testing.T) {
 	}
 }
 
+func TestRecordSetOwnershipTransferDoesNotMutateInputOnError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":"boom"}`)
+	}))
+	defer server.Close()
+
+	client := newOwnershipTransferClient(server.URL)
+	rs := &RecordSet{
+		ZoneID:       "123",
+		ID:           "456",
+		Name:         "name",
+		Type:         "CNAME",
+		TTL:          200,
+		OwnerGroupID: "owner-group-id",
+		Records: []Record{{
+			CName: "cname",
+		}},
+	}
+
+	_, err := client.RecordSetOwnershipTransferApprove(rs, "requested-group-id")
+	if err == nil {
+		t.Fatal("expected ownership transfer to fail")
+	}
+	if rs.OwnerGroupID != "owner-group-id" {
+		t.Error("expected ownerGroupId to remain unchanged on failure")
+	}
+	if rs.RecordSetGroupChange != nil {
+		t.Error("expected RecordSetGroupChange to remain nil on failure")
+	}
+}
+
 func runOwnershipTransferTest(t *testing.T, status OwnershipTransferStatus, updateOwnerGroup bool) []byte {
 	t.Helper()
 

--- a/vinyldns/recordsets_ownership_test.go
+++ b/vinyldns/recordsets_ownership_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/recordsets_resources.go
+++ b/vinyldns/recordsets_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -15,13 +15,17 @@ package vinyldns
 // RecordSetChange represents a record
 // set change.
 type RecordSetChange struct {
-	Zone       Zone      `json:"zone"`
-	RecordSet  RecordSet `json:"recordSet"`
-	UserID     string    `json:"userId"`
-	ChangeType string    `json:"changeType"`
-	Status     string    `json:"status"`
-	Created    string    `json:"created"`
-	ID         string    `json:"id"`
+	Zone                 Zone      `json:"zone"`
+	RecordSet            RecordSet `json:"recordSet"`
+	Updates              RecordSet `json:"updates,omitempty"`
+	UserID               string    `json:"userId"`
+	UserName             string    `json:"userName,omitempty"`
+	ChangeType           string    `json:"changeType"`
+	Status               string    `json:"status"`
+	SystemMessage        string    `json:"systemMessage,omitempty"`
+	Created              string    `json:"created"`
+	ID                   string    `json:"id"`
+	SingleBatchChangeIDs []string  `json:"singleBatchChangeIds,omitempty"`
 }
 
 // RecordSetChanges represents a recordset changes response

--- a/vinyldns/recordsets_resources.go
+++ b/vinyldns/recordsets_resources.go
@@ -38,22 +38,47 @@ type RecordSetChanges struct {
 	Status           string            `json:"status,omitempty"`
 }
 
+// OwnershipTransferStatus represents the record set ownership transfer status.
+type OwnershipTransferStatus string
+
+const (
+	// OwnershipTransferStatusAutoApproved indicates the transfer was auto-approved.
+	OwnershipTransferStatusAutoApproved OwnershipTransferStatus = "AutoApproved"
+	// OwnershipTransferStatusCancelled indicates the transfer was cancelled.
+	OwnershipTransferStatusCancelled OwnershipTransferStatus = "Cancelled"
+	// OwnershipTransferStatusManuallyApproved indicates the transfer was manually approved.
+	OwnershipTransferStatusManuallyApproved OwnershipTransferStatus = "ManuallyApproved"
+	// OwnershipTransferStatusManuallyRejected indicates the transfer was manually rejected.
+	OwnershipTransferStatusManuallyRejected OwnershipTransferStatus = "ManuallyRejected"
+	// OwnershipTransferStatusRequested indicates the transfer was requested.
+	OwnershipTransferStatusRequested OwnershipTransferStatus = "Requested"
+	// OwnershipTransferStatusPendingReview indicates the transfer is pending review.
+	OwnershipTransferStatusPendingReview OwnershipTransferStatus = "PendingReview"
+)
+
+// OwnershipTransfer represents the ownership transfer data for a record set.
+type OwnershipTransfer struct {
+	OwnershipTransferStatus OwnershipTransferStatus `json:"ownershipTransferStatus,omitempty"`
+	RequestedOwnerGroupID   string                  `json:"requestedOwnerGroupId,omitempty"`
+}
+
 // RecordSet represents a DNS record set.
 type RecordSet struct {
-	ID           string   `json:"id,omitempty"`
-	ZoneID       string   `json:"zoneId"`
-	OwnerGroupID string   `json:"ownerGroupId,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Type         string   `json:"type"`
-	Status       string   `json:"status,omitempty"`
-	Created      string   `json:"created,omitempty"`
-	Updated      string   `json:"updated,omitempty"`
-	TTL          int      `json:"ttl"`
-	Account      string   `json:"account"`
-	Records      []Record `json:"records"`
-	FQDN         string   `json:"fqdn,omitempty"`
-	ZoneName     string   `json:"zoneName,omitempty"`
-	IsShared     *bool    `json:"zoneShared,omitempty"`
+	ID                   string             `json:"id,omitempty"`
+	ZoneID               string             `json:"zoneId"`
+	OwnerGroupID         string             `json:"ownerGroupId,omitempty"`
+	Name                 string             `json:"name,omitempty"`
+	Type                 string             `json:"type"`
+	Status               string             `json:"status,omitempty"`
+	Created              string             `json:"created,omitempty"`
+	Updated              string             `json:"updated,omitempty"`
+	TTL                  int                `json:"ttl"`
+	Account              string             `json:"account"`
+	Records              []Record           `json:"records"`
+	FQDN                 string             `json:"fqdn,omitempty"`
+	ZoneName             string             `json:"zoneName,omitempty"`
+	IsShared             *bool              `json:"zoneShared,omitempty"`
+	RecordSetGroupChange *OwnershipTransfer `json:"recordSetGroupChange,omitempty"`
 }
 
 // RecordSetUpdateResponse represents

--- a/vinyldns/recordsets_resources.go
+++ b/vinyldns/recordsets_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/recordsets_test.go
+++ b/vinyldns/recordsets_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/recordsets_test.go
+++ b/vinyldns/recordsets_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -55,6 +55,23 @@ type ListFilter struct {
 type ListFilterRecordSetChanges struct {
 	StartFrom int
 	MaxItems  int
+}
+
+// DeletedZonesFilter represents the list query parameters for the deleted zones endpoint.
+type DeletedZonesFilter struct {
+	NameFilter   string
+	StartFrom    string
+	MaxItems     int
+	IgnoreAccess *bool
+}
+
+// RecordSetChangeHistoryFilter represents the list query parameters for record set change history.
+type RecordSetChangeHistoryFilter struct {
+	ZoneID     string
+	FQDN       string
+	RecordType string
+	StartFrom  string
+	MaxItems   int
 }
 
 // NameSort specifies the name sort order for record sets returned by the global list record set response.

--- a/vinyldns/resources.go
+++ b/vinyldns/resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/resources_test.go
+++ b/vinyldns/resources_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/resources_test.go
+++ b/vinyldns/resources_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/status.go
+++ b/vinyldns/status.go
@@ -12,13 +12,24 @@ limitations under the License.
 
 package vinyldns
 
-// groupsList retrieves the list of zones with the List criteria passed.
-func (c *Client) groupsList(filter ListFilter) (*Groups, error) {
-	groups := &Groups{}
-	err := resourceRequest(c, groupsListEP(c, filter), "GET", nil, groups)
+// Status retrieves the current system processing status.
+func (c *Client) Status() (SystemStatus, error) {
+	status := &SystemStatus{}
+	err := resourceRequest(c, statusEP(c), "GET", nil, status)
 	if err != nil {
-		return groups, err
+		return SystemStatus{}, err
 	}
 
-	return groups, nil
+	return *status, nil
+}
+
+// StatusUpdate updates the system processing status.
+func (c *Client) StatusUpdate(processingDisabled bool) (SystemStatus, error) {
+	status := &SystemStatus{}
+	err := resourceRequest(c, statusUpdateEP(c, processingDisabled), "POST", nil, status)
+	if err != nil {
+		return SystemStatus{}, err
+	}
+
+	return *status, nil
 }

--- a/vinyldns/status.go
+++ b/vinyldns/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/status_resources.go
+++ b/vinyldns/status_resources.go
@@ -12,13 +12,10 @@ limitations under the License.
 
 package vinyldns
 
-// groupsList retrieves the list of zones with the List criteria passed.
-func (c *Client) groupsList(filter ListFilter) (*Groups, error) {
-	groups := &Groups{}
-	err := resourceRequest(c, groupsListEP(c, filter), "GET", nil, groups)
-	if err != nil {
-		return groups, err
-	}
-
-	return groups, nil
+// SystemStatus represents VinylDNS processing status data.
+type SystemStatus struct {
+	ProcessingDisabled bool   `json:"processingDisabled"`
+	Color              string `json:"color,omitempty"`
+	KeyName            string `json:"keyName,omitempty"`
+	Version            string `json:"version,omitempty"`
 }

--- a/vinyldns/status_resources.go
+++ b/vinyldns/status_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/status_test.go
+++ b/vinyldns/status_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import "testing"
+
+func TestStatus(t *testing.T) {
+	statusJSON := `{"processingDisabled":false,"color":"blue","keyName":"vinyldns.","version":"0.21.3"}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/status",
+			code:     200,
+			body:     statusJSON,
+		},
+	})
+	defer server.Close()
+
+	status, err := client.Status()
+	if err != nil {
+		t.Error(err)
+	}
+	if status.Color != "blue" {
+		t.Error("Expected status.Color to be blue")
+	}
+}
+
+func TestStatusUpdate(t *testing.T) {
+	statusJSON := `{"processingDisabled":true,"color":"blue","keyName":"vinyldns.","version":"0.21.3"}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/status?processingDisabled=true",
+			code:     200,
+			body:     statusJSON,
+		},
+	})
+	defer server.Close()
+
+	status, err := client.StatusUpdate(true)
+	if err != nil {
+		t.Error(err)
+	}
+	if !status.ProcessingDisabled {
+		t.Error("Expected status.ProcessingDisabled to be true")
+	}
+}

--- a/vinyldns/status_test.go
+++ b/vinyldns/status_test.go
@@ -53,3 +53,18 @@ func TestStatusUpdate(t *testing.T) {
 		t.Error("Expected status.ProcessingDisabled to be true")
 	}
 }
+
+func TestStatusUpdateError(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/status?processingDisabled=true",
+			code:     500,
+			body:     `{"error":"failed"}`,
+		},
+	})
+	defer server.Close()
+
+	if _, err := client.StatusUpdate(true); err == nil {
+		t.Error("Expected status update error")
+	}
+}

--- a/vinyldns/status_test.go
+++ b/vinyldns/status_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/users.go
+++ b/vinyldns/users.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+// User retrieves a user by ID or username.
+func (c *Client) User(userIdentifier string) (UserInfo, error) {
+	user := &UserInfo{}
+	err := resourceRequest(c, userEP(c, userIdentifier), "GET", nil, user)
+	if err != nil {
+		return UserInfo{}, err
+	}
+
+	return *user, nil
+}
+
+// UserLock locks a user account.
+func (c *Client) UserLock(userID string) (UserInfo, error) {
+	user := &UserInfo{}
+	err := resourceRequest(c, userLockEP(c, userID), "PUT", nil, user)
+	if err != nil {
+		return UserInfo{}, err
+	}
+
+	return *user, nil
+}
+
+// UserUnlock unlocks a user account.
+func (c *Client) UserUnlock(userID string) (UserInfo, error) {
+	user := &UserInfo{}
+	err := resourceRequest(c, userUnlockEP(c, userID), "PUT", nil, user)
+	if err != nil {
+		return UserInfo{}, err
+	}
+
+	return *user, nil
+}

--- a/vinyldns/users.go
+++ b/vinyldns/users.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/users_resources.go
+++ b/vinyldns/users_resources.go
@@ -12,15 +12,10 @@ limitations under the License.
 
 package vinyldns
 
-// UserGroup represents a group ID entry for user responses.
-type UserGroup struct {
-	ID string `json:"id,omitempty"`
-}
-
 // UserInfo represents user details from user endpoints.
 type UserInfo struct {
-	ID         string      `json:"id,omitempty"`
-	UserName   string      `json:"userName,omitempty"`
-	GroupID    []UserGroup `json:"groupId,omitempty"`
-	LockStatus string      `json:"lockStatus,omitempty"`
+	ID         string   `json:"id,omitempty"`
+	UserName   string   `json:"userName,omitempty"`
+	GroupID    []string `json:"groupId,omitempty"`
+	LockStatus string   `json:"lockStatus,omitempty"`
 }

--- a/vinyldns/users_resources.go
+++ b/vinyldns/users_resources.go
@@ -12,13 +12,15 @@ limitations under the License.
 
 package vinyldns
 
-// groupsList retrieves the list of zones with the List criteria passed.
-func (c *Client) groupsList(filter ListFilter) (*Groups, error) {
-	groups := &Groups{}
-	err := resourceRequest(c, groupsListEP(c, filter), "GET", nil, groups)
-	if err != nil {
-		return groups, err
-	}
+// UserGroup represents a group ID entry for user responses.
+type UserGroup struct {
+	ID string `json:"id,omitempty"`
+}
 
-	return groups, nil
+// UserInfo represents user details from user endpoints.
+type UserInfo struct {
+	ID         string      `json:"id,omitempty"`
+	UserName   string      `json:"userName,omitempty"`
+	GroupID    []UserGroup `json:"groupId,omitempty"`
+	LockStatus string      `json:"lockStatus,omitempty"`
 }

--- a/vinyldns/users_resources.go
+++ b/vinyldns/users_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/users_test.go
+++ b/vinyldns/users_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import "testing"
+
+func TestUser(t *testing.T) {
+	userJSON := `{"id":"ok","userName":"ok","groupId":[{"id":"ok-group"}]}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/users/ok",
+			code:     200,
+			body:     userJSON,
+		},
+	})
+	defer server.Close()
+
+	user, err := client.User("ok")
+	if err != nil {
+		t.Error(err)
+	}
+	if user.ID != "ok" {
+		t.Error("Expected user ID to be ok")
+	}
+}
+
+func TestUserLock(t *testing.T) {
+	lockJSON := `{"id":"ok","userName":"ok","lockStatus":"Locked"}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/users/ok/lock",
+			code:     200,
+			body:     lockJSON,
+		},
+	})
+	defer server.Close()
+
+	user, err := client.UserLock("ok")
+	if err != nil {
+		t.Error(err)
+	}
+	if user.LockStatus != "Locked" {
+		t.Error("Expected lock status to be Locked")
+	}
+}
+
+func TestUserUnlock(t *testing.T) {
+	unlockJSON := `{"id":"ok","userName":"ok","lockStatus":"Unlocked"}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/users/ok/unlock",
+			code:     200,
+			body:     unlockJSON,
+		},
+	})
+	defer server.Close()
+
+	user, err := client.UserUnlock("ok")
+	if err != nil {
+		t.Error(err)
+	}
+	if user.LockStatus != "Unlocked" {
+		t.Error("Expected lock status to be Unlocked")
+	}
+}

--- a/vinyldns/users_test.go
+++ b/vinyldns/users_test.go
@@ -15,7 +15,7 @@ package vinyldns
 import "testing"
 
 func TestUser(t *testing.T) {
-	userJSON := `{"id":"ok","userName":"ok","groupId":[{"id":"ok-group"}]}`
+	userJSON := `{"id":"ok","userName":"ok","groupId":["ok-group"]}`
 	server, client := testTools([]testToolsConfig{
 		{
 			endpoint: "http://host.com/users/ok",

--- a/vinyldns/users_test.go
+++ b/vinyldns/users_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/users_test.go
+++ b/vinyldns/users_test.go
@@ -73,3 +73,18 @@ func TestUserUnlock(t *testing.T) {
 		t.Error("Expected lock status to be Unlocked")
 	}
 }
+
+func TestUserLockError(t *testing.T) {
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/users/ok/lock",
+			code:     500,
+			body:     `{"error":"failed"}`,
+		},
+	})
+	defer server.Close()
+
+	if _, err := client.UserLock("ok"); err == nil {
+		t.Error("Expected user lock error")
+	}
+}

--- a/vinyldns/util.go
+++ b/vinyldns/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -90,4 +90,52 @@ func resourceRequest(c *Client, url, method string, body []byte, responseStruct 
 		return err
 	}
 	return nil
+}
+
+func resourceRequestRaw(c *Client, url, method string, body []byte) (int, string, error) {
+	if logRequests() {
+		fmt.Printf("Request url: \n\t%s\nrequest body: \n\t%s \n\n", url, string(body))
+	}
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	if err != nil {
+		return 0, "", err
+	}
+
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("Content-Type", "application/json")
+
+	signer := awsauth.NewSigner()
+	creds := awscred.NewStaticCredentialsProvider(c.AccessKey, c.SecretKey, "")
+
+	h := sha256.New()
+	_, _ = io.Copy(h, bytes.NewReader(body))
+	payloadHash := hex.EncodeToString(h.Sum(nil))
+	err = signer.SignHTTP(nil, creds.Value, req, payloadHash, "VinylDNS", "us-east-1", time.Now())
+	if err != nil {
+		return 0, "", err
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+
+	bodyContents, err := io.ReadAll(resp.Body)
+	if logRequests() {
+		fmt.Printf("Response status: \n\t%d\nresponse body: \n\t%s \n\n", resp.StatusCode, bodyContents)
+	}
+	if err != nil {
+		return resp.StatusCode, "", err
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
+		dError := &Error{}
+		dError.RequestURL = url
+		dError.RequestMethod = method
+		dError.RequestBody = string(body)
+		dError.ResponseCode = resp.StatusCode
+		dError.ResponseBody = string(bodyContents)
+		return resp.StatusCode, "", dError
+	}
+
+	return resp.StatusCode, string(bodyContents), nil
 }

--- a/vinyldns/util.go
+++ b/vinyldns/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/util.go
+++ b/vinyldns/util.go
@@ -68,6 +68,7 @@ func resourceRequest(c *Client, url, method string, body []byte, responseStruct 
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	bodyContents, err := io.ReadAll(resp.Body)
 	if logRequests() {
@@ -119,6 +120,7 @@ func resourceRequestRaw(c *Client, url, method string, body []byte) (int, string
 	if err != nil {
 		return 0, "", err
 	}
+	defer resp.Body.Close()
 
 	bodyContents, err := io.ReadAll(resp.Body)
 	if logRequests() {

--- a/vinyldns/util.go
+++ b/vinyldns/util.go
@@ -41,13 +41,13 @@ func concatStrs(delim string, str ...string) string {
 	return strings.Join(str, delim)
 }
 
-func resourceRequest(c *Client, url, method string, body []byte, responseStruct interface{}) error {
+func signedRequest(c *Client, url, method string, body []byte) (int, []byte, error) {
 	if logRequests() {
 		fmt.Printf("Request url: \n\t%s\nrequest body: \n\t%s \n\n", url, string(body))
 	}
 	req, err := http.NewRequest(method, url, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return 0, nil, err
 	}
 
 	req.Header.Set("User-Agent", c.UserAgent)
@@ -61,12 +61,12 @@ func resourceRequest(c *Client, url, method string, body []byte, responseStruct 
 	payloadHash := hex.EncodeToString(h.Sum(nil))
 	err = signer.SignHTTP(nil, creds.Value, req, payloadHash, "VinylDNS", "us-east-1", time.Now())
 	if err != nil {
-		return err
+		return 0, nil, err
 	}
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return err
+		return 0, nil, err
 	}
 	defer resp.Body.Close()
 
@@ -75,7 +75,7 @@ func resourceRequest(c *Client, url, method string, body []byte, responseStruct 
 		fmt.Printf("Response status: \n\t%d\nresponse body: \n\t%s \n\n", resp.StatusCode, bodyContents)
 	}
 	if err != nil {
-		return err
+		return resp.StatusCode, nil, err
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
 		dError := &Error{}
@@ -84,8 +84,18 @@ func resourceRequest(c *Client, url, method string, body []byte, responseStruct 
 		dError.RequestBody = string(body)
 		dError.ResponseCode = resp.StatusCode
 		dError.ResponseBody = string(bodyContents)
-		return dError
+		return resp.StatusCode, nil, dError
 	}
+
+	return resp.StatusCode, bodyContents, nil
+}
+
+func resourceRequest(c *Client, url, method string, body []byte, responseStruct interface{}) error {
+	_, bodyContents, err := signedRequest(c, url, method, body)
+	if err != nil {
+		return err
+	}
+
 	err = json.Unmarshal(bodyContents, responseStruct)
 	if err != nil {
 		return err
@@ -94,50 +104,10 @@ func resourceRequest(c *Client, url, method string, body []byte, responseStruct 
 }
 
 func resourceRequestRaw(c *Client, url, method string, body []byte) (int, string, error) {
-	if logRequests() {
-		fmt.Printf("Request url: \n\t%s\nrequest body: \n\t%s \n\n", url, string(body))
-	}
-	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	statusCode, bodyContents, err := signedRequest(c, url, method, body)
 	if err != nil {
-		return 0, "", err
+		return statusCode, "", err
 	}
 
-	req.Header.Set("User-Agent", c.UserAgent)
-	req.Header.Set("Content-Type", "application/json")
-
-	signer := awsauth.NewSigner()
-	creds := awscred.NewStaticCredentialsProvider(c.AccessKey, c.SecretKey, "")
-
-	h := sha256.New()
-	_, _ = io.Copy(h, bytes.NewReader(body))
-	payloadHash := hex.EncodeToString(h.Sum(nil))
-	err = signer.SignHTTP(nil, creds.Value, req, payloadHash, "VinylDNS", "us-east-1", time.Now())
-	if err != nil {
-		return 0, "", err
-	}
-
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return 0, "", err
-	}
-	defer resp.Body.Close()
-
-	bodyContents, err := io.ReadAll(resp.Body)
-	if logRequests() {
-		fmt.Printf("Response status: \n\t%d\nresponse body: \n\t%s \n\n", resp.StatusCode, bodyContents)
-	}
-	if err != nil {
-		return resp.StatusCode, "", err
-	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
-		dError := &Error{}
-		dError.RequestURL = url
-		dError.RequestMethod = method
-		dError.RequestBody = string(body)
-		dError.ResponseCode = resp.StatusCode
-		dError.ResponseBody = string(bodyContents)
-		return resp.StatusCode, "", dError
-	}
-
-	return resp.StatusCode, string(bodyContents), nil
+	return statusCode, string(bodyContents), nil
 }

--- a/vinyldns/util_test.go
+++ b/vinyldns/util_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/util_test.go
+++ b/vinyldns/util_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/version.go
+++ b/vinyldns/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/version.go
+++ b/vinyldns/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/zones.go
+++ b/vinyldns/zones.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -75,6 +75,17 @@ func (c *Client) ZoneDetails(id string) (ZoneDetails, error) {
 	return zoneDetails.ZoneDetails, nil
 }
 
+// ZoneBackendIDs retrieves all configured DNS backend IDs.
+func (c *Client) ZoneBackendIDs() ([]string, error) {
+	var ids []string
+	err := resourceRequest(c, zoneBackendIDsEP(c), "GET", nil, &ids)
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
 // ZoneByID retrieves the Zone whose ID it's passed.
 // It is a version of Zone whose func name is a bit more explicit.
 func (c *Client) ZoneByID(id string) (Zone, error) {
@@ -90,6 +101,47 @@ func (c *Client) ZoneByName(name string) (Zone, error) {
 	}
 
 	return zone.Zone, nil
+}
+
+// ZonesDeleted retrieves deleted zone information with the filter passed.
+func (c *Client) ZonesDeleted(filter DeletedZonesFilter) (*DeletedZonesResponse, error) {
+	zones := &DeletedZonesResponse{}
+	err := resourceRequest(c, zoneDeletedChangesEP(c, filter), "GET", nil, zones)
+	if err != nil {
+		return &DeletedZonesResponse{}, err
+	}
+
+	return zones, nil
+}
+
+// ZoneACLRuleCreate adds an ACL rule to the zone.
+func (c *Client) ZoneACLRuleCreate(zoneID string, rule *ACLRule) (*ZoneUpdateResponse, error) {
+	ruleJSON, err := json.Marshal(rule)
+	if err != nil {
+		return nil, err
+	}
+	resource := &ZoneUpdateResponse{}
+	err = resourceRequest(c, zoneACLRulesEP(c, zoneID), "PUT", ruleJSON, resource)
+	if err != nil {
+		return &ZoneUpdateResponse{}, err
+	}
+
+	return resource, nil
+}
+
+// ZoneACLRuleDelete deletes an ACL rule from the zone.
+func (c *Client) ZoneACLRuleDelete(zoneID string, rule *ACLRule) (*ZoneUpdateResponse, error) {
+	ruleJSON, err := json.Marshal(rule)
+	if err != nil {
+		return nil, err
+	}
+	resource := &ZoneUpdateResponse{}
+	err = resourceRequest(c, zoneACLRulesEP(c, zoneID), "DELETE", ruleJSON, resource)
+	if err != nil {
+		return &ZoneUpdateResponse{}, err
+	}
+
+	return resource, nil
 }
 
 // ZoneCreate creates the Zone it's passed.
@@ -178,6 +230,17 @@ func (c *Client) ZoneChanges(id string) (*ZoneChanges, error) {
 	}
 
 	return zh, nil
+}
+
+// ZoneChangesFailure retrieves failed zone changes with the filter passed.
+func (c *Client) ZoneChangesFailure(filter ListFilter) (*ZoneChangeFailuresResponse, error) {
+	failures := &ZoneChangeFailuresResponse{}
+	err := resourceRequest(c, zoneChangesFailureEP(c, filter), "GET", nil, failures)
+	if err != nil {
+		return &ZoneChangeFailuresResponse{}, err
+	}
+
+	return failures, nil
 }
 
 // ZoneChangesListAll retrieves the complete list of zone changes with the ListFilter criteria passed.

--- a/vinyldns/zones.go
+++ b/vinyldns/zones.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/zones_extra_test.go
+++ b/vinyldns/zones_extra_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+import "testing"
+
+func TestZoneBackendIDs(t *testing.T) {
+	idsJSON := `["backend-1","backend-2"]`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/zones/backendids",
+			code:     200,
+			body:     idsJSON,
+		},
+	})
+	defer server.Close()
+
+	ids, err := client.ZoneBackendIDs()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(ids) != 2 {
+		t.Error("Expected backend IDs to have length 2")
+	}
+}
+
+func TestZonesDeleted(t *testing.T) {
+	deletedJSON := `{
+		"zonesDeletedInfo": [
+			{
+				"zoneChange": {
+					"zone": {
+						"name": "ok.",
+						"email": "test@test.com",
+						"status": "Deleted",
+						"id": "z1"
+					},
+					"userId": "u1",
+					"changeType": "Delete",
+					"status": "Synced",
+					"created": "now",
+					"id": "c1"
+				},
+				"adminGroupName": "admins",
+				"userName": "test",
+				"accessLevel": "NoAccess"
+			}
+		],
+		"maxItems": 100,
+		"ignoreAccess": true
+	}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/zones/deleted/changes",
+			code:     200,
+			body:     deletedJSON,
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.ZonesDeleted(DeletedZonesFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(resp.ZonesDeletedInfo) != 1 {
+		t.Error("Expected zonesDeletedInfo to have one entry")
+	}
+}
+
+func TestZoneACLRuleCreate(t *testing.T) {
+	zoneJSON, err := readFile("test-fixtures/zones/zone-update.json")
+	if err != nil {
+		t.Error(err)
+	}
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/zones/123/acl/rules",
+			code:     202,
+			body:     zoneJSON,
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.ZoneACLRuleCreate("123", &ACLRule{
+		AccessLevel: "Write",
+		GroupID:     "456",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if resp.Status == "" {
+		t.Error("Expected zone update status to have a value")
+	}
+}
+
+func TestZoneACLRuleDelete(t *testing.T) {
+	zoneJSON, err := readFile("test-fixtures/zones/zone-update.json")
+	if err != nil {
+		t.Error(err)
+	}
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/zones/123/acl/rules",
+			code:     202,
+			body:     zoneJSON,
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.ZoneACLRuleDelete("123", &ACLRule{
+		AccessLevel: "Write",
+		GroupID:     "456",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if resp.Status == "" {
+		t.Error("Expected zone update status to have a value")
+	}
+}
+
+func TestZoneChangesFailure(t *testing.T) {
+	failuresJSON := `{
+		"failedZoneChanges": [
+			{
+				"zone": {
+					"name": "ok.",
+					"email": "test@test.com",
+					"status": "Active",
+					"id": "z1"
+				},
+				"userId": "u1",
+				"changeType": "Sync",
+				"status": "Failed",
+				"created": "now",
+				"id": "c1"
+			}
+		],
+		"maxItems": 100
+	}`
+	server, client := testTools([]testToolsConfig{
+		{
+			endpoint: "http://host.com/metrics/health/zonechangesfailure",
+			code:     200,
+			body:     failuresJSON,
+		},
+	})
+	defer server.Close()
+
+	resp, err := client.ZoneChangesFailure(ListFilter{})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(resp.FailedZoneChanges) != 1 {
+		t.Error("Expected failedZoneChanges to have one entry")
+	}
+}

--- a/vinyldns/zones_extra_test.go
+++ b/vinyldns/zones_extra_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/zones_health_resources.go
+++ b/vinyldns/zones_health_resources.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 Comcast Cable Communications Management, LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vinyldns
+
+// DeletedZoneInfo represents details for a deleted zone response.
+type DeletedZoneInfo struct {
+	ZoneChange     ZoneChange `json:"zoneChange"`
+	AdminGroupName string     `json:"adminGroupName,omitempty"`
+	UserName       string     `json:"userName,omitempty"`
+	AccessLevel    string     `json:"accessLevel,omitempty"`
+}
+
+// DeletedZonesResponse represents the deleted zones response.
+type DeletedZonesResponse struct {
+	ZonesDeletedInfo []DeletedZoneInfo `json:"zonesDeletedInfo"`
+	StartFrom        string            `json:"startFrom,omitempty"`
+	NextID           string            `json:"nextId,omitempty"`
+	MaxItems         int               `json:"maxItems,omitempty"`
+	IgnoreAccess     bool              `json:"ignoreAccess,omitempty"`
+}
+
+// ZoneChangeFailuresResponse represents the failed zone changes response.
+type ZoneChangeFailuresResponse struct {
+	FailedZoneChanges []ZoneChange `json:"failedZoneChanges"`
+	StartFrom         int          `json:"startFrom,omitempty"`
+	NextID            int          `json:"nextId,omitempty"`
+	MaxItems          int          `json:"maxItems,omitempty"`
+}

--- a/vinyldns/zones_health_resources.go
+++ b/vinyldns/zones_health_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/zones_helpers.go
+++ b/vinyldns/zones_helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/zones_helpers.go
+++ b/vinyldns/zones_helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/zones_resources.go
+++ b/vinyldns/zones_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -106,10 +106,11 @@ type ZoneChanges struct {
 
 // ZoneChange represents a zone change
 type ZoneChange struct {
-	Zone       Zone   `json:"zone"`
-	UserID     string `json:"userId"`
-	ChangeType string `json:"changeType"`
-	Status     string `json:"status"`
-	Created    string `json:"created"`
-	ID         string `json:"id"`
+	Zone          Zone   `json:"zone"`
+	UserID        string `json:"userId"`
+	ChangeType    string `json:"changeType"`
+	Status        string `json:"status"`
+	SystemMessage string `json:"systemMessage,omitempty"`
+	Created       string `json:"created"`
+	ID            string `json:"id"`
 }

--- a/vinyldns/zones_resources.go
+++ b/vinyldns/zones_resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/zones_test.go
+++ b/vinyldns/zones_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Comcast Cable Communications Management, LLC
+Copyright 2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/vinyldns/zones_test.go
+++ b/vinyldns/zones_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 Comcast Cable Communications Management, LLC
+Copyright 2018-2026 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## Summary
- add endpoint builders and query helpers for new health/status, zones, recordsets, groups, users, and batch-review routes
- add client methods for Ping/Health/Color/Prometheus metrics, status get/update, backend IDs, deleted zones, ACL rule add/delete, recordset count/history/failures, group change/valid domains, user get/lock/unlock, and batch review actions
- add ownership transfer helpers for record sets (request/approve/reject/cancel) that wrap RecordSetUpdate payloads
- add resource structs for new responses and extend existing change models with extra fields used by new endpoints
- add raw request helper for text-based endpoints
- add unit tests for all new endpoints and methods

## Files Touched
- `vinyldns/endpoints.go`, `vinyldns/endpoints_test.go`
- `vinyldns/health.go`, `vinyldns/status.go`, `vinyldns/users.go`, `vinyldns/batch_changes.go`
- `vinyldns/zones.go`, `vinyldns/recordsets.go`, `vinyldns/groups.go`
- `vinyldns/*_resources.go` (status, users, recordsets, zone health, group change fields)
- new tests: `vinyldns/*_test.go` for each new area
- various files: updating copyright year from 2018 to 2026

## Manual Test Checklist
Prereqs:
- `VINYLDNS_HOST`, `VINYLDNS_ACCESS_KEY`, `VINYLDNS_SECRET_KEY` set
- Admin creds for status update, user lock/unlock, ACL rules, batch review
- Sample IDs: zoneId, groupChangeId, batchChangeId (pending review), userId/username

Health & Monitoring:
- Ping returns `PONG`
- Health returns OK (no error)
- Color returns `blue` or `green`
- Prometheus metrics return non-empty text

Status:
- GET returns `processingDisabled`, `color`, `keyName`, `version`
- POST update flips `processingDisabled` (admin)

Zone:
- Backend IDs list is non-empty
- Zone details include admin group ID/name
- Deleted zones list returns expected entries
- ACL rule add/delete returns Accepted/Pending (admin)
- Zone change failures list returns entries (can be empty)

RecordSet:
- Recordset count returns integer
- Recordset change history returns list for fqdn/type
- Recordset change failures list returns entries (can be empty)
- Ownership transfer request/approve/reject/cancel succeeds with valid record set and owner group IDs

Group:
- Valid domains list returns entries
- Group change lookup returns change details

User (admin):
- User lookup returns id/username/groups
- User lock returns `Locked`
- User unlock returns `Unlocked`

Batch Review (admin, manual review enabled):
- Approve returns updated batch status
- Reject returns updated batch status
- Cancel returns updated batch status

## Automated Tests
- go test ./...

VDNS-251