### PR TITLE
Bump version to 0.9.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.17
+VERSION=0.9.18
 SOURCE?=./...
 VINYLDNS_REPO=github.com/vinyldns/vinyldns
 VINYLDNS_DIR="$(GOPATH)/src/$(VINYLDNS_REPO)/" 

--- a/vinyldns/version.go
+++ b/vinyldns/version.go
@@ -13,4 +13,4 @@ limitations under the License.
 package vinyldns
 
 // Version stores the go-vinyldns semantic version
-var Version = "0.9.17"
+var Version = "0.9.18"


### PR DESCRIPTION
## Summary
- bump `VERSION` in `Makefile` to `0.9.18`
- bump `vinyldns.Version` to `0.9.18`

## Verification
- `make validate-version`